### PR TITLE
turns purse maker into the beginning of an issuer. other cleanups

### DIFF
--- a/examples/contract/contractTest.js
+++ b/examples/contract/contractTest.js
@@ -1,3 +1,4 @@
+/*global Vow*/
 // Copyright (C) 2011 Google Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,12 +26,13 @@ import { bobMaker } from './makeBob';
 export async function mintTest() {
   const mP = Vow.resolve(mintMaker).e.makeMint();
   const alicePurseP = mP.e.mint(1000, 'alice');
-  const depositPurseP = alicePurseP.e.makeEmptyPurse('deposit');
+  const mIssuerP = alicePurseP.e.getIssuer();
+  const depositPurseP = mIssuerP.e.makeEmptyPurse('deposit');
   const v = depositPurseP.e.deposit(50, alicePurseP.fork()); // hack
   // this ordering should be guaranteed by the fact that this is all in the
   // same Flow
-  const aBal = v.then(() => alicePurseP.e.getBalance());
-  const dBal = v.then(() => depositPurseP.e.getBalance());
+  const aBal = v.then(_ => alicePurseP.e.getBalance());
+  const dBal = v.then(_ => depositPurseP.e.getBalance());
   return Vow.all([aBal, dBal]);
 }
 

--- a/examples/contract/escrow.js
+++ b/examples/contract/escrow.js
@@ -1,8 +1,9 @@
+/*global Vow def*/
 export function escrowExchange(a, b) {  // a from Alice , b from Bob
   function makeTransfer(srcPurseP, dstPurseP, amount) {
-    const makeEscrowPurseMakerP = Vow.join(srcPurseP.e.getPurseMaker(),
-                                           dstPurseP.e.getPurseMaker());
-    const escrowPurseP = makeEscrowPurseMakerP.e.makeEmptyPurse("escrow");
+    const issuerP = Vow.join(srcPurseP.e.getIssuer(),
+                             dstPurseP.e.getIssuer());
+    const escrowPurseP = issuerP.e.makeEmptyPurse("escrow");
     return def({
       phase1() { return escrowPurseP.e.deposit(amount, srcPurseP); },
       phase2() { return dstPurseP.e.deposit(amount, escrowPurseP); },
@@ -11,7 +12,9 @@ export function escrowExchange(a, b) {  // a from Alice , b from Bob
   }
 
   function failOnly(cancellationP) {
-    return Vow.resolve(cancellationP).then(cancellation => { throw cancellation; });
+    return Vow.resolve(cancellationP).then(cancellation => {
+      throw cancellation;
+    });
   }
 
   const aT = makeTransfer(a.moneySrcP, b.moneyDstP, b.moneyNeeded);

--- a/examples/contract/makeContractHost.js
+++ b/examples/contract/makeContractHost.js
@@ -1,3 +1,4 @@
+/*global SES Vow Flow def log*/
 // Copyright (C) 2012 Google Inc.
 // Copyright (C) 2018 Agoric
 //

--- a/examples/contract/makeMint.js
+++ b/examples/contract/makeMint.js
@@ -1,3 +1,4 @@
+/*global Vow Flow def Nat*/
 // Copyright (C) 2012 Google Inc.
 // Copyright (C) 2018 Agoric
 //
@@ -15,33 +16,44 @@
 
 let counter = 0;
 function makeMint() {
-  const m = new WeakMap();
-  const maker = def({
+  // Map from purse or payment to balance
+  const ledger = new WeakMap();
+
+  const issuer = def({
     makeEmptyPurse(name) { return mint(0, name); }
   });
 
-  const mint = function(balance, name) {
+  const mint = function(initialBalance, name) {
     const purse = def({
-      getBalance: function() { return balance; },
-      getPurseMaker() { return maker; },
-      makeEmptyPurse(name) { return maker.makeEmptyPurse(name); },
+      getBalance: function() { return ledger.get(purse); },
+      getIssuer() { return issuer; },
       deposit: function(amount, srcP) {
+        amount = Nat(amount);
         counter += 1;
         const c = counter;
-        //log(`deposit[${name}]#${c}: bal=${balance} amt=${amount}`);
+        //log(`deposit[${name}]#${c}: bal=${ledger.get(purse)} amt=${amount}`);
         return Vow.resolve(srcP).then(src => {
-          //log(` dep[${name}]#${c} (post-P): bal=${balance} amt=${amount}`);
-          Nat(balance + amount);
-          m.get(src)(Nat(amount), c);
-          balance += amount;
+          //log(` dep[${name}]#${c} (post-P): bal=${
+          // ledger.get(purse)} amt=${amount}`);
+          const myOldBal = Nat(ledger.get(purse));
+          const srcOldBal = Nat(ledger.get(src));
+          Nat(myOldBal + amount);
+          const srcNewBal = Nat(srcOldBal - amount);
+          /////////////////// commit point //////////////////
+          // All queries above passed with no side effects.
+          // During side effects below, any early exits should be made into
+          // fatal turn aborts.
+          ledger.set(src, srcNewBal);
+          // In case purse and src are the same, add to purse's updated
+          // balance rather than myOldBal above. The current balance must be
+          // >= 0 and <= myOldBal, so no additional Nat test is needed.
+          // This is good because we're after the commit point, where no
+          // non-fatal errors are allowed.
+          ledger.set(purse, ledger.get(purse) + amount);
         });
       }
     });
-    const decr = function(amount, c) {
-      //log(`-decr[${name}]#${c}: bal=${balance} amt=${amount}`);
-      balance = Nat(balance - amount);
-    };
-    m.set(purse, decr);
+    ledger.set(purse, initialBalance);
     return purse;
   };
   return def({ mint });

--- a/package.json
+++ b/package.json
@@ -8,20 +8,20 @@
     "test": "tape -r esm test/**/test*.js"
   },
   "devDependencies": {
-    "esm": "^3.0.74",
+    "esm": "^3.0.80",
     "rollup-plugin-node-resolve": "^3.3.0",
-    "tape": "^4.9.0",
+    "tape": "^4.9.1",
     "tape-promise": "^3.0.0"
   },
   "dependencies": {
-    "ses": "^0.1.2",
-    "rollup": "^0.63.5",
-    "yargs": "^12.0.1",
-    "libp2p": "^0.23.1",
-    "libp2p-tcp": "^0.12.0",
     "@nodeutils/defaults-deep": "^1.1.0",
+    "libp2p": "^0.23.1",
+    "libp2p-tcp": "^0.12.1",
+    "pull-pushable": "^2.2.0",
     "pull-split": "^0.2.0",
-    "pull-pushable": "^2.2.0"
+    "rollup": "^0.63.5",
+    "ses": "^0.1.3",
+    "yargs": "^12.0.1"
   },
   "repository": {
     "type": "git",

--- a/src/flow/flowcomm.js
+++ b/src/flow/flowcomm.js
@@ -55,6 +55,7 @@ function PendingDelivery(op, args, resultR) {
     try {
       res = target[op](...args);
     } catch (ex) {
+      log(`****#### ${op} ####****`);
       res = Promise.reject(ex); // todo: make this a Vow.reject, once that exists
     }
     // resultR shouldn't ever throw an exception, but just in case let's look


### PR DESCRIPTION
Renamed the purse maker, for making an empty purse, into issuer, to be the start on a more genuine issuer ala ERTP, WebMart, WaterkenIOU, etc (This is in preparation for splitting purses into purses and payments.)

Added comments at the beginning of some files like `/*global Vow def*/` which lets JSHint know what the expected free variable references are. This has already helped catch some misspellings via JSHint's emacs highlighting.

Normalized the style of a bunch of `.then` callbacks to one-arg arrow functions.

Factored out a bunch of `Vow.resolve`s to restore code brevity elsewhere. This is a termporary measure until we transition away from the `.e.` syntax.

Fixed some lines that went past 80 columns. Please stay within 80 columns when practical!

Internal to the mint code, switched from the old `decr` function technique to James Noble's more elegant ledger structure, which is also more like what we'll do on blockchains anyway.
