### PR TITLE
fixes issue #10. checks if node version >= current LTS (10.15.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "vat": "bin/vat"
   },
   "scripts": {
-    "test": "tape -r esm test/**/test*.js"
+    "test": "tape -r esm test/test-node-version.js && tape -r esm test/**/test*.js"
   },
   "devDependencies": {
     "esm": "^3.2.4",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "SES Launcher",
   "main": "src/index.js",
   "module": "src/main.js",
+  "engines": {
+    "node": ">=10.15.1"
+  },
   "bin": {
     "vat": "bin/vat"
   },
@@ -25,6 +28,7 @@
     "pull-pushable": "^2.2.0",
     "pull-split": "^0.2.0",
     "rollup": "^1.1.2",
+    "semver": "^5.6.0",
     "ses": "^0.3.0",
     "yargs": "^13.1.0"
   },

--- a/test/test-node-version.js
+++ b/test/test-node-version.js
@@ -1,0 +1,9 @@
+import semver from 'semver';
+import { test } from 'tape-promise/tape';
+
+
+test('Node version', (t) => {
+  t.true(semver.satisfies(process.version, '>=10.15.1'));
+  t.end();
+});
+


### PR DESCRIPTION
Note that the package.json key "engines" doesn't enforce anything most of the time, which is why the test is added. 

[npm says](https://docs.npmjs.com/files/package.json#engines):
> "Unless the user has set the engine-strict config flag, this field is advisory only and will only produce warnings when your package is installed as a dependency."

[Semver](https://www.npmjs.com/package/semver) is a relatively simple package that knows about versioning. 