### PR TITLE
remove remaining `log` objects

### DIFF
--- a/src/host.js
+++ b/src/host.js
@@ -41,7 +41,7 @@ export function makeVatEndowments(s, output, comms) {
     },
   };
 
-  function build(power, log) {
+  function build(power) {
     function eventually(f) {
       Promise.resolve().then(_ => f());
     }
@@ -96,10 +96,7 @@ export function makeVatEndowments(s, output, comms) {
     });
   }
 
-  function log(...args) {
-    console.log(...args);
-  }
-  return s.evaluate(`(${build})`)(power, log);
+  return s.evaluate(`(${build})`)(power);
 }
 
 export function readAndHashFile(fn) {

--- a/src/main.js
+++ b/src/main.js
@@ -18,10 +18,7 @@ import { makeSwissnum } from './vat/swissCrypto';
 
 export function confineVatSource(s, source) {
   const exports = {};
-  function log(...args) {
-    console.log(...args);
-  }
-  const endow = { exports, log, console };
+  const endow = { exports, console };
   s.evaluate(source, endow);
   return exports;
 }

--- a/src/vat/index.js
+++ b/src/vat/index.js
@@ -1,7 +1,7 @@
-// this file is evaluated in the SES realm and defines the Vat. It gets two
-// endowments: 'module' (used to export everything) and 'log' (which wraps
-// console.log). Both of these come from the primal realm, so they must not
-// be exposed to guest code.
+// this file is evaluated in the SES realm and defines the Vat. It gets one
+// endowments: 'module' (used to export everything). This comes from the
+// primal realm, so it must not be exposed to guest code.
+// TODO: I'm not sure that comment is correct anymore -warner
 
 import { isVow, asVow, Flow, Vow, makePresence, makeUnresolvedRemoteVow } from '../flow/flowcomm';
 import { resolutionOf, handlerOf } from '../flow/flowcomm'; // todo unclean
@@ -14,10 +14,7 @@ function confineGuestSource(source, endowments) {
   endowments = endowments || {};
   const exports = {};
   const module = { exports };
-  function guestLog(...args) {
-    log(...args);
-  }
-  const endow = { module, exports, log: guestLog, console };
+  const endow = { module, exports };
   if (endowments) {
     Object.defineProperties(endow,
                             Object.getOwnPropertyDescriptors(endowments));

--- a/test/m1/m2.js
+++ b/test/m1/m2.js
@@ -1,5 +1,5 @@
 function m2() {
-  log('in m2');
+  console.log('in m2');
   debugger;
   return 1;
 }

--- a/test/test-marshal.js
+++ b/test/test-marshal.js
@@ -15,7 +15,7 @@ test('marshal', async (t) => {
 
   function helpers() {
     function serializer(x) {
-      log(x);
+      console.log(x);
     }
     const ref1 = { a() { return 1; } };
     const val = {

--- a/test/test-vat2.js
+++ b/test/test-vat2.js
@@ -8,7 +8,7 @@ function t1_sender() {
     let answer = 'unanswered';
     Vow.resolve(argv.target).e.pleaseRespond('marco')
       .then(res => {
-        log(`got answer: ${res}`);
+        console.log(`got answer: ${res}`);
         answer = res;
       });
     return {
@@ -23,7 +23,7 @@ function t1_responder() {
     return {
       pleaseRespond(arg) {
         called = true;
-        log(`pleaseRespond called with ${arg}`);
+        console.log(`pleaseRespond called with ${arg}`);
         return `${arg}-polo`;
       },
       getCalled() { return called; },
@@ -120,10 +120,10 @@ function t2_responder() {
     let answer = 'not yet';
     return {
       pleaseWait(arg) {
-        log(`pleaseWait called with ${arg}`);
+        console.log(`pleaseWait called with ${arg}`);
         called = true;
         Vow.resolve(arg).then(res => {
-          log(`resolved`);
+          console.log(`resolved`);
           answer = res;
         });
       },
@@ -249,7 +249,7 @@ function t3_two() {
     let r;
     const vtwo = new Flow().makeVow(res => r = res);
     return {
-      getVow(arg) { log('getVow'); return vtwo; },
+      getVow(arg) { console.log('getVow'); return vtwo; },
       fire(arg) { r(arg); },
     };
   };
@@ -426,7 +426,7 @@ function t4_two() {
     const vtwo = new Flow().makeVow(res => r = res);
     const presence = {};
     return {
-      getVow(arg) { log('getVow'); return vtwo; },
+      getVow(arg) { console.log('getVow'); return vtwo; },
       getPresence() { return presence; },
       fire(arg) { r(arg); },
     };
@@ -595,9 +595,9 @@ function t5_alice() {
   exports.default = function(argv) {
     let aliceDone = false;
     const v1 = new Flow().makeVow(_ => null);
-    log('alice sends to bob');
+    console.log('alice sends to bob');
     Vow.resolve(argv.bob).e.send1(v1); // got1
-    log('alice sent to bob');
+    console.log('alice sent to bob');
   };
 }
 


### PR DESCRIPTION
switch all remaining uses of explicit `log()` in tests to plain
`console.log()`, stop sending explicit `log` functions around

refs #5