### PR TITLE
Change eslint settings to match our current practices 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,8 +10,8 @@ module.exports = {
     'arrow-parens': 'off',
     strict: 'off',
     'no-console': 'off',
-
-    /// temporarily turn off until a decision is made
-    'prefer-arrow-callback': 'off',
+    'no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+    'no-return-assign': 'off',
+    'no-param-reassign': 'off',
   },
 };


### PR DESCRIPTION
This PR turns a few Airbnb recommendations off (or alters them) because we have widespread violations, many of which are intentional on our part. 

For `no-unused-vars`, I've set it such that we can have arguments to a function that are unused, but only if they have an underscore prefix. 

We should revisit these at a later date. 