### PR TITLE
ESLint changes to src/vat/webkey.js

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,8 +10,11 @@ module.exports = {
     'arrow-parens': 'off',
     strict: 'off',
     'no-console': 'off',
+
+    // revisit the following later
     'no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
     'no-return-assign': 'off',
     'no-param-reassign': 'off',
+    'import/prefer-default-export': 'off',
   },
 };

--- a/src/vat/webkey.js
+++ b/src/vat/webkey.js
@@ -1,4 +1,4 @@
-/* globals def Nat */
+/* globals def */
 
 import { makeSwissnum, makeSwissbase, doSwissHashing } from './swissCrypto';
 
@@ -63,7 +63,7 @@ function mustPassByPresence(val) {
       throw new Error(
         `cannot serialize objects with non-methods like the .${name} in ${val}`,
       );
-      return false;
+      // return false;
     }
   }
   const p = Object.getPrototypeOf(val);
@@ -228,10 +228,10 @@ export function makeWebkeyMarshal(
       if (ibidMap.has(val)) {
         throw new Error('ibid disabled for now');
         // Backreference to prior occurrence
-        return def({
-          [QCLASS]: 'ibid',
-          index: ibidMap.get(val),
-        });
+        // return def({
+        //   [QCLASS]: 'ibid',
+        //   index: ibidMap.get(val),
+        // });
       }
       ibidMap.set(val, ibidCount);
       ibidCount += 1;
@@ -312,9 +312,9 @@ export function makeWebkeyMarshal(
       return webkey2Record.get(key).value;
     }
     // console.log(` did not find previous`);
-    for (const k of webkey2Record.keys()) {
-      // console.log(` had: ${k}`);
-    }
+    // for (const k of webkey2Record.keys()) {
+    //   console.log(` had: ${k}`);
+    // }
 
     // todo: maybe pre-generate the FarVow and stash it for quick access
     const p = makePresence(serializer, data.vatID, data.swissnum);
@@ -360,16 +360,17 @@ export function makeWebkeyMarshal(
             return Symbol.for(data.key);
           }
           case 'bigint': {
+            /* eslint-disable-next-line no-undef */
             return BigInt(data.digits);
           }
 
           case 'ibid': {
             throw new Error('ibid disabled for now');
-            const index = Nat(data.index);
-            if (index >= ibids.length) {
-              throw new RangeError(`ibid out of range: ${index}`);
-            }
-            return ibids[index];
+            // const index = Nat(data.index);
+            // if (index >= ibids.length) {
+            //   throw new RangeError(`ibid out of range: ${index}`);
+            // }
+            // return ibids[index];
           }
 
           case 'vow': {
@@ -433,7 +434,7 @@ export function makeWebkeyMarshal(
   }
 
   function registerTarget(val, swissnum, resolutionOf) {
-    const rec = serializePassByPresence(val, resolutionOf, swissnum);
+    serializePassByPresence(val, resolutionOf, swissnum);
   }
 
   function getOutboundResolver(vatID, swissnum, handlerOf) {

--- a/src/vat/webkey.js
+++ b/src/vat/webkey.js
@@ -29,11 +29,8 @@ function canPassByCopy(val) {
     return false;
   }
   const names = Object.getOwnPropertyNames(val);
-  for (const name of names) {
-    if (typeof val[name] === 'function') {
-      return false;
-    }
-  }
+  const hasFunction = names.every(name => typeof val[name] === 'function');
+  if (hasFunction) return false;
   const p = Object.getPrototypeOf(val);
   if (p !== null && p !== Object.prototype && p !== Array.prototype) {
     // todo: arrays should also be Array.isArray(val)

--- a/src/vat/webkey.js
+++ b/src/vat/webkey.js
@@ -51,10 +51,12 @@ function mustPassByPresence(val) {
   if (typeof val !== 'object') {
     throw new Error(`cannot serialize non-objects like ${val}`);
   }
-  for (const name of Object.getOwnPropertyNames(val)) {
+
+  const names = Object.getOwnPropertyNames(val);
+  names.forEach(name => {
     if (name === 'e') {
       // hack to allow Vows to pass-by-presence
-      continue;
+      return;
     }
     if (typeof val[name] !== 'function') {
       throw new Error(
@@ -62,7 +64,8 @@ function mustPassByPresence(val) {
       );
       // return false;
     }
-  }
+  });
+
   const p = Object.getPrototypeOf(val);
   if (p !== null && p !== Object.prototype) {
     mustPassByPresence(p);

--- a/src/vat/webkey.js
+++ b/src/vat/webkey.js
@@ -1,5 +1,6 @@
+/* globals def Nat */
+
 import { makeSwissnum, makeSwissbase, doSwissHashing } from './swissCrypto';
-import { insist } from '../insist';
 
 // objects can only be passed in one of two/three forms:
 // 1: pass-by-presence: all properties (own and inherited) are methods,
@@ -87,22 +88,6 @@ export function makeWebkeyMarshal(
   myVatSecret,
   serializer,
 ) {
-  // val might be a primitive, a pass by (shallow) copy object, a
-  // remote reference, or other.  We treat all other as a local object
-  // to be exported as a local webkey.
-  function serialize(val, resolutionOf) {
-    return JSON.stringify(val, makeReplacer(resolutionOf));
-  }
-
-  function unserialize(str) {
-    return JSON.parse(str, makeReviver());
-  }
-
-  function makeWebkey(data) {
-    // todo: use a cheaper (but still safe/reversible) combiner
-    return JSON.stringify({ vatID: data.vatID, swissnum: data.swissnum });
-  }
-
   // Record: { value, vatID, swissnum, serialized }
   // holds both objects (pass-by-presence) and unresolved promises
   const val2Record = new WeakMap();
@@ -206,14 +191,14 @@ export function makeWebkeyMarshal(
           return val;
         }
         case 'symbol': {
-          const opt_key = Symbol.keyFor(val);
-          if (opt_key === undefined) {
+          const optKey = Symbol.keyFor(val);
+          if (optKey === undefined) {
             // TODO: Symmetric unguessable identity
             throw new TypeError('Cannot serialize unregistered symbol');
           }
           return def({
             [QCLASS]: 'symbol',
-            key: opt_key,
+            key: optKey,
           });
         }
         case 'bigint': {
@@ -296,22 +281,27 @@ export function makeWebkeyMarshal(
     };
   }
 
-  function parseSturdyref(sturdyref) {
-    const parts = sturdyref.split('/');
-    return { vatID: parts[0], swissnum: parts[1] };
+  function makeWebkey(data) {
+    // todo: use a cheaper (but still safe/reversible) combiner
+    return JSON.stringify({ vatID: data.vatID, swissnum: data.swissnum });
   }
 
-  function createPresence(sturdyref) {
-    // used to create initial argv references
-    const { vatID, swissnum } = parseSturdyref(sturdyref);
-    const serialized = {
-      [QCLASS]: 'presence',
-      vatID,
-      swissnum,
-    };
-    // this creates the Presence, and also stores it into the tables, so we
-    // can send it back out again later
-    return unserializePresence(serialized);
+  function unserializeVow(data) {
+    const key = makeWebkey(data);
+    if (webkey2Record.has(key)) {
+      return webkey2Record.get(key).value;
+    }
+    const v = makeUnresolvedRemoteVow(serializer, data.vatID, data.swissnum);
+    const rec = def({
+      value: v,
+      vatID: data.vatID,
+      swissnum: data.swissnum,
+      serialized: data,
+    });
+    val2Record.set(v, rec);
+    webkey2Record.set(key, rec);
+    serializer.opWhen(data.vatID, data.swissnum);
+    return v;
   }
 
   function unserializePresence(data) {
@@ -337,24 +327,6 @@ export function makeWebkeyMarshal(
     val2Record.set(p, rec);
     webkey2Record.set(key, rec);
     return p;
-  }
-
-  function unserializeVow(data) {
-    const key = makeWebkey(data);
-    if (webkey2Record.has(key)) {
-      return webkey2Record.get(key).value;
-    }
-    const v = makeUnresolvedRemoteVow(serializer, data.vatID, data.swissnum);
-    const rec = def({
-      value: v,
-      vatID: data.vatID,
-      swissnum: data.swissnum,
-      serialized: data,
-    });
-    val2Record.set(v, rec);
-    webkey2Record.set(key, rec);
-    serializer.opWhen(data.vatID, data.swissnum);
-    return v;
   }
 
   function makeReviver() {
@@ -423,6 +395,35 @@ export function makeWebkeyMarshal(
       ibids.push(data);
       return def(data);
     };
+  }
+
+  // val might be a primitive, a pass by (shallow) copy object, a
+  // remote reference, or other.  We treat all other as a local object
+  // to be exported as a local webkey.
+  function serialize(val, resolutionOf) {
+    return JSON.stringify(val, makeReplacer(resolutionOf));
+  }
+
+  function unserialize(str) {
+    return JSON.parse(str, makeReviver());
+  }
+
+  function parseSturdyref(sturdyref) {
+    const parts = sturdyref.split('/');
+    return { vatID: parts[0], swissnum: parts[1] };
+  }
+
+  function createPresence(sturdyref) {
+    // used to create initial argv references
+    const { vatID, swissnum } = parseSturdyref(sturdyref);
+    const serialized = {
+      [QCLASS]: 'presence',
+      vatID,
+      swissnum,
+    };
+    // this creates the Presence, and also stores it into the tables, so we
+    // can send it back out again later
+    return unserializePresence(serialized);
   }
 
   function allocateSwissStuff() {

--- a/src/vat/webkey.js
+++ b/src/vat/webkey.js
@@ -29,7 +29,7 @@ function canPassByCopy(val) {
     return false;
   }
   const names = Object.getOwnPropertyNames(val);
-  const hasFunction = names.every(name => typeof val[name] === 'function');
+  const hasFunction = names.some(name => typeof val[name] === 'function');
   if (hasFunction) return false;
   const p = Object.getPrototypeOf(val);
   if (p !== null && p !== Object.prototype && p !== Array.prototype) {


### PR DESCRIPTION
This one's a doozy. :D 

## Errors
We start out with the following errors:
<img width="847" alt="screen shot 2019-02-19 at 4 01 57 pm" src="https://user-images.githubusercontent.com/2441069/53056396-dca74d00-345f-11e9-9bd1-675fb7d60e45.png">

We also have a lot of `def` undefined errors which are not shown for conciseness.

## Fixes

The different commits are probably the best ways to view the following:

1. Reorder the functions in the file such that we don't have 'used before defined' errors. Unfortunately, the diff doesn't show this correctly.
2. Fix undefined def and Nat, remove unused insist. 
3. Comment out unreachable code, remove Nat which is unused and an unused `rec`
4. Change the `for...of` to `every` or `forEach` depending on the use

## Remaining Issues
None

## Test
`npm test`
`./node_modules/.bin/eslint --fix src/vat/webkey.js`


