### PR TITLE
use require() instead of global Nat/def/harden

### DIFF
--- a/examples/contract/escrow.js
+++ b/examples/contract/escrow.js
@@ -1,10 +1,11 @@
-/* global Vow def */
+/* global Vow */
 export function escrowExchange(a, b) {
+  const harden = require('@agoric/harden');
   // a from Alice , b from Bob
   function makeTransfer(srcPurseP, dstPurseP, amount) {
     const issuerP = Vow.join(srcPurseP.e.getIssuer(), dstPurseP.e.getIssuer());
     const escrowPurseP = issuerP.e.makeEmptyPurse('escrow');
-    return def({
+    return harden({
       phase1() {
         return escrowPurseP.e.deposit(amount, srcPurseP);
       },

--- a/examples/contract/makeAlice.js
+++ b/examples/contract/makeAlice.js
@@ -1,4 +1,4 @@
-/* global Vow Flow def */
+/* global Vow Flow */
 // Copyright (C) 2013 Google Inc.
 // Copyright (C) 2018 Agoric
 //
@@ -17,6 +17,7 @@
 import { escrowExchange } from './escrow';
 
 function makeAlice(myMoneyPurse, myStockPurse, contractHostP) {
+  const harden = require('@agoric/harden');
   const escrowSrc = `${escrowExchange}`;
   const myMoneyPurseP = Vow.resolve(myMoneyPurse);
   const myMoneyIssuerP = myMoneyPurseP.e.getIssuer();
@@ -31,14 +32,14 @@ function makeAlice(myMoneyPurse, myStockPurse, contractHostP) {
     // is in the contractHost's checking
   };
 
-  const alice = def({
+  const alice = harden({
     payBobWell(bobP) {
       const paymentP = myMoneyIssuerP.e.makeEmptyPurse();
       const ackP = paymentP.e.deposit(10, myMoneyPurseP);
       return ackP.then(_ => bobP.e.buy('shoe', paymentP));
     },
     payBobBadly1(bobP) {
-      const payment = def({ deposit(amount, src) {} });
+      const payment = harden({ deposit(amount, src) {} });
       return bobP.e.buy('shoe', payment);
     },
     payBobBadly2(bobP) {
@@ -59,7 +60,7 @@ function makeAlice(myMoneyPurse, myStockPurse, contractHostP) {
       check(allegedSrc, allegedSide);
 
       let cancel;
-      const a = def({
+      const a = harden({
         moneySrcP: myMoneyIssuerP.e.makeEmptyPurse('aliceMoneySrc'),
         stockDstP: myStockIssuerP.e.makeEmptyPurse('aliceStockDst'),
         stockNeeded: 7,

--- a/examples/contract/makeBob.js
+++ b/examples/contract/makeBob.js
@@ -1,4 +1,4 @@
-/* global Vow Flow def */
+/* global Vow Flow */
 // Copyright (C) 2013 Google Inc.
 // Copyright (C) 2018 Agoric
 //
@@ -17,6 +17,7 @@
 import { escrowExchange } from './escrow';
 
 function makeBob(myMoneyPurse, myStockPurse, contractHostP) {
+  const harden = require('@agoric/harden');
   const escrowSrc = `${escrowExchange}`;
   const myMoneyPurseP = Vow.resolve(myMoneyPurse);
   const myMoneyIssuerP = myMoneyPurseP.e.getIssuer();
@@ -31,7 +32,7 @@ function makeBob(myMoneyPurse, myStockPurse, contractHostP) {
     // is in the contractHost's checking
   };
 
-  const bob = def({
+  const bob = harden({
     /**
      * This is not an imperative to Bob to buy something but rather
      * the opposite. It is a request by a client to buy something from
@@ -78,7 +79,7 @@ function makeBob(myMoneyPurse, myStockPurse, contractHostP) {
     invite(tokenP, allegedSrc, allegedSide) {
       check(allegedSrc, allegedSide);
       let cancel;
-      const b = def({
+      const b = harden({
         stockSrcP: myStockIssuerP.e.makeEmptyPurse('bobStockSrc'),
         moneyDstP: myMoneyIssuerP.e.makeEmptyPurse('bobMoneyDst'),
         moneyNeeded: 10,

--- a/examples/contract/makeContractHost.js
+++ b/examples/contract/makeContractHost.js
@@ -1,4 +1,4 @@
-/* global SES Vow Flow def */
+/* global SES Vow Flow */
 // Copyright (C) 2012 Google Inc.
 // Copyright (C) 2018 Agoric
 //
@@ -82,9 +82,10 @@
  */
 
 export function makeContractHost() {
+  const harden = require('@agoric/harden');
   const m = new WeakMap();
 
-  return def({
+  return harden({
     setup(contractSrc) {
       contractSrc = `${contractSrc}`;
       const tokens = [];
@@ -92,7 +93,7 @@ export function makeContractHost() {
       let resolve;
       const f = new Flow();
       const resultP = f.makeVow(r => (resolve = r));
-      const contract = SES.confineExpr(contractSrc, { Flow, Vow, console });
+      const contract = SES.confineExpr(contractSrc, { Flow, Vow, console, require });
 
       const addParam = function(i, token) {
         tokens[i] = token;
@@ -111,7 +112,7 @@ export function makeContractHost() {
         });
       };
       for (let i = 0; i < contract.length; i++) {
-        addParam(i, def({}));
+        addParam(i, harden({}));
       }
       resolve(
         Vow.all(argPs).then(function(args) {

--- a/examples/contract/makeMint.js
+++ b/examples/contract/makeMint.js
@@ -1,4 +1,4 @@
-/* global Vow Flow def Nat */
+/* global Vow Flow */
 // Copyright (C) 2012 Google Inc.
 // Copyright (C) 2018 Agoric
 //
@@ -14,19 +14,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+const Nat = require('@agoric/nat');
+const harden = require('@agoric/harden');
+
 let counter = 0;
 function makeMint() {
   // Map from purse or payment to balance
   const ledger = new WeakMap();
 
-  const issuer = def({
+  const issuer = harden({
     makeEmptyPurse(name) {
       return mint(0, name);
     },
   });
 
   const mint = function(initialBalance, name) {
-    const purse = def({
+    const purse = harden({
       getBalance() {
         return ledger.get(purse);
       },
@@ -62,7 +65,7 @@ function makeMint() {
     ledger.set(purse, initialBalance);
     return purse;
   };
-  return def({ mint });
+  return harden({ mint });
 }
 
 export const mintMaker = {

--- a/examples/contract/simple_auction.js
+++ b/examples/contract/simple_auction.js
@@ -30,12 +30,13 @@
  */
 define('contract/simple_auction', ['Q'], function(Q) {
   "use strict";
-   
+  const harden = require('@agoric/harden');
+
   var makeAuctioneer = function() {
 
     var auctions = new WeakMap(); // for rights amplification
 
-    return def({
+    return harden({
     
       /**
        * minBid = minimum bid required by the seller (a number)
@@ -49,7 +50,7 @@ define('contract/simple_auction', ['Q'], function(Q) {
         // resolveBidder refers to the "resolve" function of the promise
         // handed out to the highest bidder so far, if any
         var resolveBidder = undefined;
-        var auctionToken = def({});
+        var auctionToken = harden({});
       
         auctions.set(auctionToken, function(bid) {
           bid = +bid; // make sure bid is a number
@@ -93,7 +94,7 @@ define('contract/simple_auction', ['Q'], function(Q) {
 
 
   var makeSeller = function() {
-    return def({
+    return harden({
     
       /**
        * good = the good to auction
@@ -141,7 +142,7 @@ define('contract/simple_auction', ['Q'], function(Q) {
 
 
   var makeBidder = function() {
-    return def({
+    return harden({
     
       /**
        * goodDesc = a description of the good the bidder is interested in. This description

--- a/examples/contractHost/alice/source/index.js
+++ b/examples/contractHost/alice/source/index.js
@@ -1,4 +1,4 @@
-/* global Vow Flow def */
+/* global Vow Flow */
 // Copyright (C) 2013 Google Inc.
 // Copyright (C) 2018 Agoric
 //
@@ -13,6 +13,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+import harden from '@agoric/harden';
 
 export default function(argv) {
   const escrowSrc = argv.escrowSrc;
@@ -42,7 +44,7 @@ export default function(argv) {
     // is in the contractHost's checking
   };
 
-  const alice = def({
+  const alice = harden({
     init,
     payBobWell() {
       if (!initialized) {
@@ -56,7 +58,7 @@ export default function(argv) {
       if (!initialized) {
         console.log('++ ERR: payBobBadly1 called before init()');
       }
-      const payment = def({ deposit(amount, src) {} });
+      const payment = harden({ deposit(amount, src) {} });
       return bobP.e.buy('shoe', payment);
     },
     payBobBadly2() {
@@ -87,7 +89,7 @@ export default function(argv) {
       check(allegedSrc, allegedSide);
 
       let cancel;
-      const a = def({
+      const a = harden({
         moneySrcP: myMoneyIssuerP.e.makeEmptyPurse('aliceMoneySrc'),
         stockDstP: myStockIssuerP.e.makeEmptyPurse('aliceStockDst'),
         stockNeeded: 7,

--- a/examples/contractHost/bob/source/index.js
+++ b/examples/contractHost/bob/source/index.js
@@ -1,4 +1,4 @@
-/* global Vow Flow def */
+/* global Vow Flow */
 // Copyright (C) 2013 Google Inc.
 // Copyright (C) 2018 Agoric
 //
@@ -13,6 +13,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+import harden from '@agoric/harden';
 
 export default function(argv) {
   const escrowSrc = argv.escrowSrc;
@@ -42,7 +44,7 @@ export default function(argv) {
     // is in the contractHost's checking
   };
 
-  const bob = def({
+  const bob = harden({
     init,
     /**
      * This is not an imperative to Bob to buy something but rather
@@ -107,7 +109,7 @@ export default function(argv) {
       check(allegedSrc, allegedSide);
       console.log('++ bob.invite passed check');
       let cancel;
-      const b = def({
+      const b = harden({
         stockSrcP: myStockIssuerP.e.makeEmptyPurse('bobStockSrc'),
         moneyDstP: myMoneyIssuerP.e.makeEmptyPurse('bobMoneyDst'),
         moneyNeeded: 10,

--- a/examples/contractHost/escrow.js
+++ b/examples/contractHost/escrow.js
@@ -1,10 +1,12 @@
-/* global Vow def */
+/* global Vow */
+const harden = require('@agoric/harden');
+
 function escrowExchange(a, b) {
   // a from Alice , b from Bob
   function makeTransfer(srcPurseP, dstPurseP, amount) {
     const issuerP = Vow.join(srcPurseP.e.getIssuer(), dstPurseP.e.getIssuer());
     const escrowPurseP = issuerP.e.makeEmptyPurse('escrow');
-    return def({
+    return harden({
       phase1() {
         return escrowPurseP.e.deposit(amount, srcPurseP);
       },

--- a/examples/contractHost/host/source/index.js
+++ b/examples/contractHost/host/source/index.js
@@ -1,4 +1,4 @@
-/* global SES Vow Flow def */
+/* global SES Vow Flow */
 // Copyright (C) 2012 Google Inc.
 // Copyright (C) 2018 Agoric
 //
@@ -81,10 +81,12 @@
  * </pre>
  */
 
+import harden from '@agoric/harden';
+
 export default function(argv) {
   const m = new WeakMap();
 
-  return def({
+  return harden({
     setup(contractSrc) {
       contractSrc = `${contractSrc}`;
       const tokens = [];
@@ -92,7 +94,7 @@ export default function(argv) {
       let resolve;
       const f = new Flow();
       const resultP = f.makeVow(r => (resolve = r));
-      const contract = SES.confineExpr(contractSrc, { Flow, Vow, console });
+      const contract = SES.confineExpr(contractSrc, { Flow, Vow, console, require });
 
       const addParam = function(i, token) {
         tokens[i] = token;
@@ -111,7 +113,7 @@ export default function(argv) {
         });
       };
       for (let i = 0; i < contract.length; i++) {
-        addParam(i, def({}));
+        addParam(i, harden({}));
       }
       resolve(
         Vow.all(argPs).then(function(args) {

--- a/examples/contractHost/mint/source/index.js
+++ b/examples/contractHost/mint/source/index.js
@@ -1,4 +1,4 @@
-/* global Vow Flow def Nat */
+/* global Vow Flow */
 // Copyright (C) 2012 Google Inc.
 // Copyright (C) 2018 Agoric
 //
@@ -14,6 +14,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import Nat from '@agoric/nat';
+import harden from '@agoric/harden';
+
 export default function(argv) {
   let debugCounter = 0;
 
@@ -21,14 +24,14 @@ export default function(argv) {
     // Map from purse or payment to balance
     const ledger = new WeakMap();
 
-    const issuer = def({
+    const issuer = harden({
       makeEmptyPurse(name) {
         return mint(0, name);
       },
     });
 
     const mint = function(initialBalance, name) {
-      const purse = def({
+      const purse = harden({
         getBalance() {
           console.log(`getBalance`, ledger.get(purse));
           return ledger.get(purse);
@@ -70,7 +73,7 @@ export default function(argv) {
       ledger.set(purse, initialBalance);
       return purse;
     };
-    return def({ mint });
+    return harden({ mint });
   }
 
   return { makeMint };

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "pull-stream": "^3.6.9",
     "rollup": "^1.1.2",
     "semver": "^5.6.0",
-    "ses": "^0.3.0",
+    "ses": "^0.4.0",
     "yargs": "^13.1.0"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "lint-check": "eslint '**/*.{js,jsx}'"
   },
   "devDependencies": {
+    "@agoric/harden": "^0.0.2",
     "eslint": "^5.3.0",
     "eslint-config-airbnb": "^17.1.0",
     "eslint-config-prettier": "^4.0.0",
@@ -32,6 +33,7 @@
     "tape-promise": "^4.0.0"
   },
   "dependencies": {
+    "@agoric/nat": "^2.0.0",
     "@nodeutils/defaults-deep": "^1.1.0",
     "bs58": "^4.0.1",
     "libp2p": "^0.24.4",

--- a/src/flow/flowcomm.js
+++ b/src/flow/flowcomm.js
@@ -2,19 +2,13 @@
 
 'use strict';
 
+import harden from '@agoric/harden';
 import { insist, insistFn } from '../insist';
 
 // const debugLog = console.log;
 function debugLog() {} // disabled
 
 const scheduleHack = Promise.resolve(null);
-
-// TODO: remove this in favor of the global deep-freezing def() that SES
-// provides. However make sure test-flow.js can still work, which doesn't run
-// under SES.
-function def(x) {
-  return Object.freeze(x);
-}
 
 function isSymbol(x) {
   return typeof x === 'symbol';
@@ -192,7 +186,7 @@ class UnresolvedHandler {
     return false;
   }
 }
-def(UnresolvedHandler);
+harden(UnresolvedHandler);
 
 class FulfilledHandler {
   constructor(value) {
@@ -224,7 +218,7 @@ class FulfilledHandler {
     return true;
   }
 }
-def(FulfilledHandler);
+harden(FulfilledHandler);
 
 class FarRemoteHandler extends UnresolvedHandler {
   constructor(serializer, vatID, swissnum, presence = null) {
@@ -307,7 +301,7 @@ class FarRemoteHandler extends UnresolvedHandler {
     return super.processSingle(todo, flow);
   }
 }
-def(FarRemoteHandler);
+harden(FarRemoteHandler);
 
 class InnerFlow {
   constructor() {
@@ -361,7 +355,7 @@ class InnerFlow {
     }`;
   }
 }
-def(InnerFlow);
+harden(InnerFlow);
 
 const flowToInner = new WeakMap();
 
@@ -374,7 +368,7 @@ function realInnerFlow(value) {
 const farVows = new WeakMap(); // maps Presence to { vatID, swissnum, handler }
 
 export function makePresence(serializer, vatID, swissnum) {
-  const presence = def({});
+  const presence = harden({});
   const handler = new FarRemoteHandler(serializer, vatID, swissnum, presence);
   const rec = { vatID, swissnum, handler };
   farVows.set(presence, rec);
@@ -405,7 +399,7 @@ class Flow {
     return new Vow(flow, innerResolver);
   }
 }
-def(Flow);
+harden(Flow);
 
 // follow a chain of handlers
 function shortenForwards(firstResolver, optVow) {
@@ -437,9 +431,9 @@ function makeResolver(innerResolver) {
     innerResolver = innerResolver.resolve(value);
   };
   // resolver.toString = () => `Resolver{ resolved: ${getHandler(resolver)} }`;
-  return def(resolver);
+  return harden(resolver);
 }
-def(makeResolver);
+harden(makeResolver);
 
 const vowToInner = new WeakMap();
 const resolverToInner = new WeakMap();
@@ -489,7 +483,7 @@ class InnerVow {
   constructor(innerFlow, innerResolver) {
     this.flow = innerFlow;
     this.resolver = innerResolver;
-    // def(this);
+    // harden(this);
   }
 
   get(target, op, receiver) {
@@ -535,7 +529,7 @@ class Vow {
       value: new Proxy({}, inner),
       enumerable: false,
     });
-    // def(this);
+    // harden(this);
   }
 
   // TODO need second argument for `then`
@@ -599,7 +593,7 @@ class Vow {
     return Vow.resolve().then(() => fn());
   }
 }
-def(Vow);
+harden(Vow);
 
 const asVow = Vow.resolve;
 

--- a/src/host.js
+++ b/src/host.js
@@ -22,7 +22,7 @@ export function hash58(s) {
   return bs58.encode(h.digest().slice(0, 16));
 }
 
-export function makeVatEndowments(s, output, comms) {
+export function makeVatEndowments(s, req, output, comms) {
   const power = {
     // made available to build()
     hash58,
@@ -45,10 +45,11 @@ export function makeVatEndowments(s, output, comms) {
   };
 
   function build(power) {
+    const harden = require('@agoric/harden');
     function eventually(f) {
       Promise.resolve().then(_ => f());
     }
-    return def({
+    return harden({
       hash58(s) {
         return power.hash58(s);
       },
@@ -57,11 +58,11 @@ export function makeVatEndowments(s, output, comms) {
           // m is SES
           // the manager will be called with connectionMade, commsReceived,
           // and connectionLost
-          const wrappedManager = def({
+          const wrappedManager = harden({
             connectionMade(hostID, c) {
               // c is Primal
               // the Connection has a send() method
-              const wrappedConnection = def({
+              const wrappedConnection = harden({
                 // wrappedConnection is SES
                 send(msg) {
                   c.send(`${msg}`);
@@ -105,7 +106,7 @@ export function makeVatEndowments(s, output, comms) {
     });
   }
 
-  return s.evaluate(`(${build})`)(power);
+  return s.evaluate(`(${build})`, { require: req })(power);
 }
 
 export function readAndHashFile(fn) {

--- a/src/vat/executionEngine.js
+++ b/src/vat/executionEngine.js
@@ -1,9 +1,9 @@
 // the execution engine
+import harden from '@agoric/harden';
 import { doSwissHashing } from './swissCrypto';
 import { makeWebkeyMarshal } from './webkey';
 
 export function makeEngine(
-  def,
   hash58,
   Vow,
   isVow,
@@ -33,8 +33,8 @@ export function makeEngine(
     args,
     resolutionOf,
   ) {
-    const argsS = marshal.serialize(def(args), resolutionOf);
-    const body = def({
+    const argsS = marshal.serialize(harden(args), resolutionOf);
+    const body = harden({
       op: 'send',
       targetSwissnum,
       methodName,
@@ -45,7 +45,7 @@ export function makeEngine(
   }
 
   function opWhen(targetVatID, targetSwissnum) {
-    const body = def({ op: 'when', targetSwissnum });
+    const body = harden({ op: 'when', targetSwissnum });
     manager.sendTo(targetVatID, body);
   }
 
@@ -74,8 +74,8 @@ export function makeEngine(
   function opResolve(targetVatID, targetSwissnum, value) {
     // todo: rename targetSwissnum to mySwissnum? The thing being resolved
     // lives on the sender, not the recipient.
-    const valueS = marshal.serialize(def(value), resolutionOf);
-    const body = def({ op: 'resolve', targetSwissnum, valueS });
+    const valueS = marshal.serialize(harden(value), resolutionOf);
+    const body = harden({ op: 'resolve', targetSwissnum, valueS });
     manager.sendTo(targetVatID, body);
   }
 
@@ -178,5 +178,5 @@ export function makeEngine(
     },
   };
 
-  return def(engine);
+  return harden(engine);
 }

--- a/src/vat/index.js
+++ b/src/vat/index.js
@@ -21,7 +21,7 @@ function confineGuestSource(source, endowments) {
   endowments = endowments || {};
   const exports = {};
   const module = { exports };
-  const endow = { module, exports };
+  const endow = { module, exports, require };
   if (endowments) {
     Object.defineProperties(
       endow,
@@ -144,13 +144,11 @@ export function makeVat(
     endowments.comms,
     managerWriteInput,
     managerWriteOutput,
-    def,
     logConflict,
     endowments.hash58,
   );
 
   const engine = makeEngine(
-    def,
     endowments.hash58,
     Vow,
     isVow,

--- a/src/vat/remotes.js
+++ b/src/vat/remotes.js
@@ -1,3 +1,4 @@
+import harden from '@agoric/harden';
 import { makeScoreboard } from './scoreboard';
 import { insist } from '../insist';
 import { vatMessageIDHash } from './swissCrypto';
@@ -10,7 +11,7 @@ function buildAck(ackSeqnum) {
 const OP = 'op ';
 const DECIDE = 'decide ';
 
-export function makeRemoteForVatID(vatID, def, logConflict) {
+export function makeRemoteForVatID(vatID, logConflict) {
   let nextOutboundSeqnum = 0;
 
   // inbound management
@@ -27,7 +28,7 @@ export function makeRemoteForVatID(vatID, def, logConflict) {
     return componentIDs.size >= threshold;
   }
 
-  const scoreboard = makeScoreboard(quorumTest, def, logConflict);
+  const scoreboard = makeScoreboard(quorumTest, logConflict);
 
   function getReadyMessage() {
     if (!readyMessage) {
@@ -226,7 +227,6 @@ export function makeRemoteManager(
   comms,
   managerWriteInput,
   managerWriteOutput,
-  def,
   logConflict,
   hash58,
 ) {
@@ -245,7 +245,7 @@ export function makeRemoteManager(
       }
       hostRemotes.set(
         hostID,
-        makeRemoteForHostID(hostID, comms, def, managerWriteInput),
+        makeRemoteForHostID(hostID, comms, managerWriteInput),
       );
     }
     return hostRemotes.get(hostID);
@@ -253,7 +253,7 @@ export function makeRemoteManager(
 
   function getVatRemote(vatID) {
     if (!vatRemotes.has(vatID)) {
-      vatRemotes.set(vatID, makeRemoteForVatID(vatID, def, logConflict));
+      vatRemotes.set(vatID, makeRemoteForVatID(vatID, logConflict));
     }
     return vatRemotes.get(vatID);
   }
@@ -393,7 +393,7 @@ export function makeRemoteManager(
     }
   }
 
-  const manager = def({
+  const manager = harden({
     setEngine(e) {
       engine = e;
     },
@@ -411,13 +411,13 @@ export function makeRemoteManager(
 }
 
 // this is just for outbound messages, but todo future maybe acks too
-function makeRemoteForHostID(hostID, comms, def, managerWriteInput) {
+function makeRemoteForHostID(hostID, comms, managerWriteInput) {
   let queuedMessages = [];
   const nextInboundSeqnum = 0;
   const queuedInboundMessages = new Map(); // seqnum -> msg
   let connection;
 
-  const remote = def({
+  const remote = harden({
     connectionMade(c) {
       connection = c;
       if (nextInboundSeqnum > 0) {

--- a/src/vat/scoreboard.js
+++ b/src/vat/scoreboard.js
@@ -1,4 +1,5 @@
 import { insist } from '../insist';
+import harden from '@agoric/harden';
 
 /**
  * A scoreboard is an object that accepts proto messages, where each
@@ -23,7 +24,7 @@ import { insist } from '../insist';
  * or remember the set it is passed. By monotonic, if it says true for
  * set X, it must say true for any superset of set X.
  */
-export function makeScoreboard(quorumTest, def, logConflict) {
+export function makeScoreboard(quorumTest, logConflict) {
   // map of seqNum to sequence-maps, where a sequence-map is a map
   // from msgID to a record of a `msg` and the set of `componentIDs`
   // that have agreed on that msgID (and therefore presumably on that
@@ -45,7 +46,7 @@ export function makeScoreboard(quorumTest, def, logConflict) {
     return undefined;
   }
 
-  return def({
+  return harden({
     // Return a conservative flag about whether this acceptance might
     // have caused a next message to be ready. If false, then no next
     // message is ready; otherwise maybe.
@@ -118,7 +119,7 @@ function makeConsensusLeader(decidedQs) {
     }
   }
 
-  return def({
+  return harden({
     acceptProtoMsg(compositeID, componentID, seqNum, msgID, msg) {
       let scoreboard = scoreboards.get(compositeID);
       if (!scoreboard) {
@@ -148,7 +149,7 @@ function makeConsensusLeader(decidedQs) {
 export function makeConsensusFollower(leaderP) {
   leaderP = Vow.resolve(leaderP);
   
-  return def({
+  return harden({
     acceptProtoMsg(compositeID, componentID, seqNum, msgID, msg) {
       // BOGUS Vulnerable HACK! Must forward signed message
       // itself. The receiver must be the one that takes it apart and

--- a/src/vat/webkey.js
+++ b/src/vat/webkey.js
@@ -1,6 +1,14 @@
-/* globals def */
 
+import harden from '@agoric/harden';
 import { makeSwissnum, makeSwissbase, doSwissHashing } from './swissCrypto';
+import {
+  isVow,
+  asVow,
+  Flow,
+  Vow,
+  makePresence,
+  makeUnresolvedRemoteVow,
+} from '../flow/flowcomm';
 
 // objects can only be passed in one of two/three forms:
 // 1: pass-by-presence: all properties (own and inherited) are methods,
@@ -77,13 +85,15 @@ function mustPassByPresence(val) {
 // decoding.
 const QCLASS = '@qclass';
 
+// TODO: remove these Vow/Flow parameters now that we can import them
+// directly
 export function makeWebkeyMarshal(
   hash58,
-  Vow,
-  isVow,
-  Flow,
-  makePresence,
-  makeUnresolvedRemoteVow,
+  _Vow,
+  _isVow,
+  _Flow,
+  _makePresence,
+  _makeUnresolvedRemoteVow,
   myVatID,
   myVatSecret,
   serializer,
@@ -123,7 +133,7 @@ export function makeWebkeyMarshal(
       swissnum = allocateSwissnum();
     }
 
-    const rec = def({
+    const rec = harden({
       value: val,
       vatID: myVatID,
       swissnum,
@@ -169,7 +179,7 @@ export function makeWebkeyMarshal(
           throw new Error(`bare functions like ${val} are disabled for now`);
         }
         case 'undefined': {
-          return def({ [QCLASS]: 'undefined' });
+          return harden({ [QCLASS]: 'undefined' });
         }
         case 'string':
         case 'boolean': {
@@ -177,16 +187,16 @@ export function makeWebkeyMarshal(
         }
         case 'number': {
           if (Number.isNaN(val)) {
-            return def({ [QCLASS]: 'NaN' });
+            return harden({ [QCLASS]: 'NaN' });
           }
           if (Object.is(val, -0)) {
-            return def({ [QCLASS]: '-0' });
+            return harden({ [QCLASS]: '-0' });
           }
           if (val === Infinity) {
-            return def({ [QCLASS]: 'Infinity' });
+            return harden({ [QCLASS]: 'Infinity' });
           }
           if (val === -Infinity) {
-            return def({ [QCLASS]: '-Infinity' });
+            return harden({ [QCLASS]: '-Infinity' });
           }
           return val;
         }
@@ -196,13 +206,13 @@ export function makeWebkeyMarshal(
             // TODO: Symmetric unguessable identity
             throw new TypeError('Cannot serialize unregistered symbol');
           }
-          return def({
+          return harden({
             [QCLASS]: 'symbol',
             key: optKey,
           });
         }
         case 'bigint': {
-          return def({
+          return harden({
             [QCLASS]: 'bigint',
             digits: String(val),
           });
@@ -228,7 +238,7 @@ export function makeWebkeyMarshal(
       if (ibidMap.has(val)) {
         throw new Error('ibid disabled for now');
         // Backreference to prior occurrence
-        // return def({
+        // return harden({
         //   [QCLASS]: 'ibid',
         //   index: ibidMap.get(val),
         // });
@@ -292,7 +302,7 @@ export function makeWebkeyMarshal(
       return webkey2Record.get(key).value;
     }
     const v = makeUnresolvedRemoteVow(serializer, data.vatID, data.swissnum);
-    const rec = def({
+    const rec = harden({
       value: v,
       vatID: data.vatID,
       swissnum: data.swissnum,
@@ -318,7 +328,7 @@ export function makeWebkeyMarshal(
 
     // todo: maybe pre-generate the FarVow and stash it for quick access
     const p = makePresence(serializer, data.vatID, data.swissnum);
-    const rec = def({
+    const rec = harden({
       value: p,
       vatID: data.vatID,
       swissnum: data.swissnum,
@@ -394,7 +404,7 @@ export function makeWebkeyMarshal(
       }
       // The ibids case returned early to avoid this.
       ibids.push(data);
-      return def(data);
+      return harden(data);
     };
   }
 
@@ -461,7 +471,7 @@ export function makeWebkeyMarshal(
 
   function registerRemoteVow(targetVatID, swissnum, val) {
     // console.log(`registerRemoteVow: ${targetVatID} / ${swissnum} as ${val}`);
-    const rec = def({
+    const rec = harden({
       value: val,
       vatID: targetVatID,
       swissnum,
@@ -478,7 +488,7 @@ export function makeWebkeyMarshal(
     serializer.opWhen(targetVatID, swissnum);
   }
 
-  return def({
+  return harden({
     serialize,
     unserialize,
     allocateSwissStuff,

--- a/test/test-contract.js
+++ b/test/test-contract.js
@@ -1,4 +1,5 @@
 import { test } from 'tape-promise/tape';
+import Nat from '@agoric/nat';
 import { makeRealm, buildVat, bundleCode } from '../src/main';
 import { hash58 } from '../src/host';
 
@@ -17,11 +18,13 @@ async function buildContractVat(source = '../examples/contract') {
   function writeOutput(line) {
     outputTranscript.push(line);
   }
-  const s = makeRealm();
+  const s = makeRealm({ consoleMode: 'allow', errorStackMode: 'allow' });
+  const req = s.makeRequire({'@agoric/nat': Nat, '@agoric/harden': true});
   const contractTestSource = await bundleCode(require.resolve(source));
   const endow = { writeOutput, comms: { registerManager() {} }, hash58 };
   const v = await buildVat(
     s,
+    req,
     'v1',
     'v1 secret',
     'v1',

--- a/test/test-endowments.js
+++ b/test/test-endowments.js
@@ -1,4 +1,5 @@
 import { test } from 'tape-promise/tape';
+import Nat from '@agoric/nat';
 import SES from 'ses';
 import { makeVatEndowments } from '../src/host';
 import {
@@ -8,8 +9,9 @@ import {
 } from '../src/vat/swissCrypto';
 
 test('hash58', t => {
-  const s = SES.makeSESRootRealm();
-  const e = makeVatEndowments(s, null, null);
+  const s = SES.makeSESRootRealm({consoleMode: 'allow', errorStackMode: 'allow'});
+  const req = s.makeRequire({'@agoric/nat': Nat, '@agoric/harden': true});
+  const e = makeVatEndowments(s, req, null, null);
   // test vectors from python and electrum/lib/address.py Base58 class
   // Base58.encode(hashlib.sha256(s).digest()[:16])
   t.equal(e.hash58(''), 'V7jseQevszwMPhi4evidTR');
@@ -25,7 +27,8 @@ test('hash58', t => {
 
 test.skip('swissHashing', t => {
   const s = SES.makeSESRootRealm();
-  const e = makeVatEndowments(s, null, null);
+  const req = s.makeRequire({'@agoric/nat': Nat, '@agoric/harden': true});
+  const e = makeVatEndowments(s, req, null, null);
   const vs = e.hash58('vat secret');
   t.equal(vs, 'WHMV2quAubLYGoFtXtpEao');
   const sw1 = makeSwissnum(vs, 1, e.hash58);

--- a/test/test-nat.js
+++ b/test/test-nat.js
@@ -1,11 +1,13 @@
 /* global Nat */
 
 import { test } from 'tape-promise/tape';
+import Nat from '@agoric/nat';
 import SES from 'ses';
 import { confineVatSource } from '../src/main';
 
 function s1() {
   exports.foo = a => {
+    const Nat = require('@agoric/nat');
     return Nat(a);
   };
 }
@@ -19,8 +21,9 @@ function funcToSource(f) {
 
 test('Nat', t => {
   const s = SES.makeSESRootRealm();
+  const req = s.makeRequire({'@agoric/nat': Nat, '@agoric/harden': true});
   const s1code = funcToSource(s1);
-  const n = confineVatSource(s, s1code).foo;
+  const n = confineVatSource(s, req, s1code).foo;
   t.equal(n(2), 2);
   t.end();
 });

--- a/test/test-pipeline.js
+++ b/test/test-pipeline.js
@@ -1,6 +1,7 @@
 /* global Vow */
 
 import { test } from 'tape-promise/tape';
+import Nat from '@agoric/nat';
 import { makeRealm, buildVat } from '../src/main';
 import { makeTranscript, funcToSource, makeQueues } from './util';
 import { hash58 } from '../src/host';
@@ -54,8 +55,10 @@ test('promise pipelining', async t => {
     hash58,
   };
   const s = makeRealm();
+  const req = s.makeRequire({'@agoric/nat': Nat, '@agoric/harden': true});
   const v1 = await buildVat(
     s,
+    req,
     'vat1',
     'vat1 secret',
     'vat1',
@@ -67,6 +70,7 @@ test('promise pipelining', async t => {
 
   const v2 = await buildVat(
     s,
+    req,
     'vat2',
     'vat2 secret',
     'vat2',
@@ -222,8 +226,10 @@ test('promise pipelining to third party', async t => {
     hash58,
   };
   const s = makeRealm();
+  const req = s.makeRequire({'@agoric/nat': Nat, '@agoric/harden': true});
   const v1 = await buildVat(
     s,
+    req,
     'vat1',
     'vat1 secret',
     'vat1',
@@ -236,6 +242,7 @@ test('promise pipelining to third party', async t => {
 
   const v2 = await buildVat(
     s,
+    req,
     'vat2',
     'vat2 secret',
     'vat2',
@@ -248,6 +255,7 @@ test('promise pipelining to third party', async t => {
 
   const v3 = await buildVat(
     s,
+    req,
     'vat3',
     'vat3 secret',
     'vat3',

--- a/test/test-vat.js
+++ b/test/test-vat.js
@@ -1,4 +1,5 @@
 import { test } from 'tape-promise/tape';
+import Nat from '@agoric/nat';
 import SES from 'ses';
 import { promisify } from 'util';
 import { confineVatSource, makeRealm, buildVat, bundleCode } from '../src/main';
@@ -58,10 +59,11 @@ function s2() {
 }
 
 test('confineVatSource', t => {
-  const s = SES.makeSESRootRealm();
+  const s = SES.makeSESRootRealm({ consoleMode: 'allow' });
   const s1code = funcToSource(s1);
   // console.log(`source: ${s1code}`);
-  const e = confineVatSource(s, `${s1code}`).default();
+  const req = s.makeRequire({'@agoric/nat': Nat, '@agoric/harden': true});
+  const e = confineVatSource(s, req, `${s1code}`).default();
   t.equal(e.increment(), 1);
   t.equal(e.increment(), 2);
   t.equal(e.decrement(), 1);
@@ -72,12 +74,13 @@ test('methods can send messages via doSendOnly', async t => {
   // todo remove
   const tr = makeTranscript();
   const s = makeRealm();
+  const req = s.makeRequire({'@agoric/nat': Nat, '@agoric/harden': true});
   const endow = {
     writeOutput: tr.writeOutput,
     comms: { registerManager() {}, wantConnection() {} },
     hash58,
   };
-  const v = await buildVat(s, 'v1', 'v1 secret', 'v1', endow, funcToSource(s2));
+  const v = await buildVat(s, req, 'v1', 'v1 secret', 'v1', endow, funcToSource(s2));
   await v.initializeCode('v1/0');
 
   const opMsg = {
@@ -127,12 +130,13 @@ test('methods can send messages via doSendOnly', async t => {
 test('methods can send messages via commsReceived', async t => {
   const tr = makeTranscript();
   const s = makeRealm();
+  const req = s.makeRequire({'@agoric/nat': Nat, '@agoric/harden': true});
   const endow = {
     writeOutput: tr.writeOutput,
     comms: { registerManager() {}, wantConnection() {} },
     hash58,
   };
-  const v = await buildVat(s, 'v1', 'v1 secret', 'v1', endow, funcToSource(s2));
+  const v = await buildVat(s, req, 'v1', 'v1 secret', 'v1', endow, funcToSource(s2));
   await v.initializeCode('v1/0');
 
   const opMsg = {
@@ -190,12 +194,13 @@ test('methods can send messages via commsReceived', async t => {
 test('method results are sent back', async t => {
   const tr = makeTranscript();
   const s = makeRealm();
+  const req = s.makeRequire({'@agoric/nat': Nat, '@agoric/harden': true});
   const endow = {
     writeOutput: tr.writeOutput,
     comms: { registerManager() {}, wantConnection() {} },
     hash58,
   };
-  const v = await buildVat(s, 'v1', 'v1 secret', 'v1', endow, funcToSource(s2));
+  const v = await buildVat(s, req, 'v1', 'v1 secret', 'v1', endow, funcToSource(s2));
   await v.initializeCode('v1/0');
   const opMsg = {
     op: 'send',
@@ -231,12 +236,13 @@ test('method results are sent back', async t => {
 test('methods can return a promise', async t => {
   const tr = makeTranscript();
   const s = makeRealm();
+  const req = s.makeRequire({'@agoric/nat': Nat, '@agoric/harden': true});
   const endow = {
     writeOutput: tr.writeOutput,
     comms: { registerManager() {}, wantConnection() {} },
     hash58,
   };
-  const v = await buildVat(s, 'v1', 'v1 secret', 'v1', endow, funcToSource(s2));
+  const v = await buildVat(s, req, 'v1', 'v1 secret', 'v1', endow, funcToSource(s2));
   await v.initializeCode('v1/0');
 
   let result = false;

--- a/test/test-vat2.js
+++ b/test/test-vat2.js
@@ -1,4 +1,5 @@
 import { test } from 'tape-promise/tape';
+import Nat from '@agoric/nat';
 import { confineVatSource, makeRealm, buildVat, bundleCode } from '../src/main';
 import { makeTranscript, funcToSource, makeQueues } from './util';
 import { hash58 } from '../src/host';
@@ -43,14 +44,15 @@ test('comms, sending a message', async t => {
     comms: { registerManager() {}, wantConnection() {} },
     hash58,
   };
-  const s = makeRealm();
+  const s = makeRealm({ consoleMode: 'allow' });
+  const req = s.makeRequire({'@agoric/nat': Nat, '@agoric/harden': true});
   const v1src = funcToSource(t1_sender);
-  const v1 = await buildVat(s, 'vat1', 'vat1 secret', 'vat1', endow, v1src);
+  const v1 = await buildVat(s, req, 'vat1', 'vat1 secret', 'vat1', endow, v1src);
   const v1argv = { target: v1.createPresence('vat2/0') };
   const v1root = await v1.initializeCode('vat1/0', v1argv);
 
   const v2src = funcToSource(t1_responder);
-  const v2 = await buildVat(s, 'vat2', 'vat2 secret', 'vat2', endow, v2src);
+  const v2 = await buildVat(s, req, 'vat2', 'vat2 secret', 'vat2', endow, v2src);
   const v2argv = {};
   const v2root = await v2.initializeCode('vat2/0', v2argv);
   const q = makeQueues(t);
@@ -159,14 +161,15 @@ test('sending unresolved local Vow', async t => {
     comms: { registerManager() {}, wantConnection() {} },
     hash58,
   };
-  const s = makeRealm();
+  const s = makeRealm({ consoleMode: 'allow' });
+  const req = s.makeRequire({'@agoric/nat': Nat, '@agoric/harden': true});
   const v1src = funcToSource(t2_sender);
-  const v1 = await buildVat(s, 'vat1', 'vat1 secret', 'vat1', endow, v1src);
+  const v1 = await buildVat(s, req, 'vat1', 'vat1 secret', 'vat1', endow, v1src);
   const v1argv = { target: v1.createPresence('vat2/0') };
   const v1root = await v1.initializeCode('vat1/0', v1argv);
 
   const v2src = funcToSource(t2_responder);
-  const v2 = await buildVat(s, 'vat2', 'vat2 secret', 'vat2', endow, v2src);
+  const v2 = await buildVat(s, req, 'vat2', 'vat2 secret', 'vat2', endow, v2src);
   const v2argv = {};
   const v2root = await v2.initializeCode('vat2/0', v2argv);
   const q = makeQueues(t);
@@ -316,9 +319,10 @@ test('sending third-party Vow', async t => {
     comms: { registerManager() {}, wantConnection() {} },
     hash58,
   };
-  const s = makeRealm();
+  const s = makeRealm({ consoleMode: 'allow' });
+  const req = s.makeRequire({'@agoric/nat': Nat, '@agoric/harden': true});
   const v1src = funcToSource(t3_one);
-  const v1 = await buildVat(s, 'vat1', 'vat1 secret', 'vat1', endow, v1src);
+  const v1 = await buildVat(s, req, 'vat1', 'vat1 secret', 'vat1', endow, v1src);
   const v1argv = {
     target2: v1.createPresence('vat2/0'),
     target3: v1.createPresence('vat3/0'),
@@ -326,12 +330,12 @@ test('sending third-party Vow', async t => {
   const v1root = await v1.initializeCode('vat1/0', v1argv);
 
   const v2src = funcToSource(t3_two);
-  const v2 = await buildVat(s, 'vat2', 'vat2 secret', 'vat2', endow, v2src);
+  const v2 = await buildVat(s, req, 'vat2', 'vat2 secret', 'vat2', endow, v2src);
   const v2argv = {};
   const v2root = await v2.initializeCode('vat2/0', v2argv);
 
   const v3src = funcToSource(t3_three);
-  const v3 = await buildVat(s, 'vat3', 'vat3 secret', 'vat3', endow, v3src);
+  const v3 = await buildVat(s, req, 'vat3', 'vat3 secret', 'vat3', endow, v3src);
   const v3argv = {};
   const v3root = await v3.initializeCode('vat3/0', v3argv);
   const q = makeQueues(t);
@@ -527,9 +531,10 @@ test('sending third-party Vow that resolves to Presence', async t => {
     comms: { registerManager() {}, wantConnection() {} },
     hash58,
   };
-  const s = makeRealm();
+  const s = makeRealm({ consoleMode: 'allow' });
+  const req = s.makeRequire({'@agoric/nat': Nat, '@agoric/harden': true});
   const v1src = funcToSource(t4_one);
-  const v1 = await buildVat(s, 'vat1', 'vat1 secret', 'vat1', endow, v1src);
+  const v1 = await buildVat(s, req, 'vat1', 'vat1 secret', 'vat1', endow, v1src);
   const v1argv = {
     target2: v1.createPresence('vat2/0'),
     target3: v1.createPresence('vat3/0'),
@@ -537,12 +542,12 @@ test('sending third-party Vow that resolves to Presence', async t => {
   const v1root = await v1.initializeCode('vat1/0', v1argv);
 
   const v2src = funcToSource(t4_two);
-  const v2 = await buildVat(s, 'vat2', 'vat2 secret', 'vat2', endow, v2src);
+  const v2 = await buildVat(s, req, 'vat2', 'vat2 secret', 'vat2', endow, v2src);
   const v2argv = {};
   const v2root = await v2.initializeCode('vat2/0', v2argv);
 
   const v3src = funcToSource(t4_three);
-  const v3 = await buildVat(s, 'vat3', 'vat3 secret', 'vat3', endow, v3src);
+  const v3 = await buildVat(s, req, 'vat3', 'vat3 secret', 'vat3', endow, v3src);
   const v3argv = {};
   const v3root = await v3.initializeCode('vat3/0', v3argv);
   const q = makeQueues(t);
@@ -745,12 +750,14 @@ test('third-party Vow gets resolved', async t => {
     comms: { registerManager() {}, wantConnection() {} },
     hash58,
   };
-  const s = makeRealm();
+  const s = makeRealm({ consoleMode: 'allow' });
+  const req = s.makeRequire({'@agoric/nat': Nat, '@agoric/harden': true});
 
   const ALICE = 'ALICE';
   const alice_src = funcToSource(t5_alice);
   const vatALICE = await buildVat(
     s,
+    req,
     'vatALICE',
     'aSecret',
     'vatALICE',
@@ -764,6 +771,7 @@ test('third-party Vow gets resolved', async t => {
   const bob_src = funcToSource(t5_bob);
   const vatBOB = await buildVat(
     s,
+    req,
     'vatBOB',
     'bSecret',
     'vatBOB',
@@ -777,6 +785,7 @@ test('third-party Vow gets resolved', async t => {
   const carol_src = funcToSource(t5_carol);
   const vatCAROL = await buildVat(
     s,
+    req,
     'vatCAROL',
     'cSecret',
     'vatCAROL',


### PR DESCRIPTION
This changes the Vat code to use SES's new `s.makeRequire()` helper, so both host and guest code can use things like `Nat = require('@agoric/nat')` and `harden = require('@agoric/harden')`. When guest code with these imports is run outside of SES, they get the usual npm versions. When it runs inside SES, it gets corresponding in-realm objects, so we can write unit tests of the individual pieces without having to go through hoops.

refs #19 