### PR TITLE
ESLint changes to examples/contract/escrow.js

### DIFF
--- a/examples/contract/escrow.js
+++ b/examples/contract/escrow.js
@@ -1,5 +1,6 @@
 /* global Vow */
 export function escrowExchange(a, b) {
+  /* eslint-disable-next-line global-require, import/no-extraneous-dependencies */
   const harden = require('@agoric/harden');
   // a from Alice , b from Bob
   function makeTransfer(srcPurseP, dstPurseP, amount) {
@@ -31,7 +32,7 @@ export function escrowExchange(a, b) {
     failOnly(a.cancellationP),
     failOnly(b.cancellationP),
   ]).then(
-    x => Vow.all([aT.phase2(), bT.phase2()]),
-    ex => Vow.all([aT.abort(), bT.abort()]),
+    _x => Vow.all([aT.phase2(), bT.phase2()]),
+    _ex => Vow.all([aT.abort(), bT.abort()]),
   );
 }


### PR DESCRIPTION
No template because the changes are small - fix intentionally unused arguments, and disable the errors around the `require` of `harden` that is written that way for use in SES. 