### PR TITLE
ESLint changes to examples/contract/makeAlice.js and makeBob.js

### DIFF
--- a/examples/contract/makeAlice.js
+++ b/examples/contract/makeAlice.js
@@ -17,16 +17,18 @@
 import { escrowExchange } from './escrow';
 
 function makeAlice(myMoneyPurse, myStockPurse, contractHostP) {
+  /* eslint-disable-next-line global-require, import/no-extraneous-dependencies */
   const harden = require('@agoric/harden');
   const escrowSrc = `${escrowExchange}`;
   const myMoneyPurseP = Vow.resolve(myMoneyPurse);
   const myMoneyIssuerP = myMoneyPurseP.e.getIssuer();
   const myStockPurseP = Vow.resolve(myStockPurse);
   const myStockIssuerP = myStockPurseP.e.getIssuer();
+  /* eslint-disable-next-line no-param-reassign */
   contractHostP = Vow.resolve(contractHostP);
   const f = new Flow();
 
-  const check = function(allegedSrc, allegedSide) {
+  const check = (_allegedSrc, _allegedSide) => {
     // for testing purposes, alice and bob are willing to play
     // any side of any contract, so that the failure we're testing
     // is in the contractHost's checking
@@ -39,7 +41,7 @@ function makeAlice(myMoneyPurse, myStockPurse, contractHostP) {
       return ackP.then(_ => bobP.e.buy('shoe', paymentP));
     },
     payBobBadly1(bobP) {
-      const payment = harden({ deposit(amount, src) {} });
+      const payment = harden({ deposit(_amount, _src) {} });
       return bobP.e.buy('shoe', payment);
     },
     payBobBadly2(bobP) {
@@ -59,14 +61,13 @@ function makeAlice(myMoneyPurse, myStockPurse, contractHostP) {
     invite(tokenP, allegedSrc, allegedSide) {
       check(allegedSrc, allegedSide);
 
+      /* eslint-disable-next-line no-unused-vars */
       let cancel;
       const a = harden({
         moneySrcP: myMoneyIssuerP.e.makeEmptyPurse('aliceMoneySrc'),
         stockDstP: myStockIssuerP.e.makeEmptyPurse('aliceStockDst'),
         stockNeeded: 7,
-        cancellationP: f.makeVow(function(r) {
-          cancel = r;
-        }),
+        cancellationP: f.makeVow(r => (cancel = r)),
       });
       const ackP = a.moneySrcP.e.deposit(10, myMoneyPurseP);
 

--- a/examples/contract/makeBob.js
+++ b/examples/contract/makeBob.js
@@ -17,6 +17,7 @@
 import { escrowExchange } from './escrow';
 
 function makeBob(myMoneyPurse, myStockPurse, contractHostP) {
+  /* eslint-disable-next-line global-require, import/no-extraneous-dependencies */
   const harden = require('@agoric/harden');
   const escrowSrc = `${escrowExchange}`;
   const myMoneyPurseP = Vow.resolve(myMoneyPurse);
@@ -26,7 +27,7 @@ function makeBob(myMoneyPurse, myStockPurse, contractHostP) {
   contractHostP = Vow.resolve(contractHostP);
   const f = new Flow();
 
-  const check = function(allegedSrc, allegedSide) {
+  const check = (_allegedSrc, _allegedSide) => {
     // for testing purposes, alice and bob are willing to play
     // any side of any contract, so that the failure we're testing
     // is in the contractHost's checking
@@ -40,6 +41,7 @@ function makeBob(myMoneyPurse, myStockPurse, contractHostP) {
      * is a bit confusing here.
      */
     buy(desc, paymentP) {
+      /* eslint-disable-next-line no-unused-vars */
       let amount;
       let good;
       desc = `${desc}`;
@@ -78,14 +80,13 @@ function makeBob(myMoneyPurse, myStockPurse, contractHostP) {
      */
     invite(tokenP, allegedSrc, allegedSide) {
       check(allegedSrc, allegedSide);
+      /* eslint-disable-next-line no-unused-vars */
       let cancel;
       const b = harden({
         stockSrcP: myStockIssuerP.e.makeEmptyPurse('bobStockSrc'),
         moneyDstP: myMoneyIssuerP.e.makeEmptyPurse('bobMoneyDst'),
         moneyNeeded: 10,
-        cancellationP: f.makeVow(function(r) {
-          cancel = r;
-        }),
+        cancellationP: f.makeVow(r => (cancel = r)),
       });
       const ackP = b.stockSrcP.e.deposit(7, myStockPurse);
 


### PR DESCRIPTION
## Errors
makeAlice.js:
![screen shot 2019-02-21 at 12 06 08 pm](https://user-images.githubusercontent.com/2441069/53198388-24011b00-35d1-11e9-8d57-de35eccb98a8.png)

makeBob.js:
![screen shot 2019-02-21 at 12 13 15 pm](https://user-images.githubusercontent.com/2441069/53198768-18faba80-35d2-11e9-94fc-9c11e83ff84b.png)


## Fixes
1. allow require of `@agoric/harden`
2. allow param reassign
3. fix intentionally unused args
4. allow `cancel` to go unused because it's important to note that it could be used.
