### PR TITLE
ESLint changes for examples/contractHost/alice and /bob 

### DIFF
--- a/examples/contractHost/alice/source/index.js
+++ b/examples/contractHost/alice/source/index.js
@@ -14,10 +14,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/* eslint-disable-next-line global-require, import/no-extraneous-dependencies */
 import harden from '@agoric/harden';
 
 export default function(argv) {
-  const escrowSrc = argv.escrowSrc;
+  const { escrowSrc } = argv;
   const contractHostP = Vow.resolve(argv.host);
   const bobP = Vow.resolve(argv.bob);
 
@@ -35,10 +36,11 @@ export default function(argv) {
     myMoneyIssuerP = myMoneyPurseP.e.getIssuer();
     myStockPurseP = Vow.resolve(myStockPurse);
     myStockIssuerP = myStockPurseP.e.getIssuer();
-    return alice;
+    /* eslint-disable-next-line no-use-before-define */
+    return alice; // alice and init use each other
   }
 
-  const check = function(allegedSrc, allegedSide) {
+  const check = (_allegedSrc, _allegedSide) => {
     // for testing purposes, alice and bob are willing to play
     // any side of any contract, so that the failure we're testing
     // is in the contractHost's checking
@@ -58,7 +60,7 @@ export default function(argv) {
       if (!initialized) {
         console.log('++ ERR: payBobBadly1 called before init()');
       }
-      const payment = harden({ deposit(amount, src) {} });
+      const payment = harden({ deposit(_amount, _src) {} });
       return bobP.e.buy('shoe', payment);
     },
     payBobBadly2() {
@@ -88,14 +90,13 @@ export default function(argv) {
 
       check(allegedSrc, allegedSide);
 
+      /* eslint-disable-next-line no-unused-vars */
       let cancel;
       const a = harden({
         moneySrcP: myMoneyIssuerP.e.makeEmptyPurse('aliceMoneySrc'),
         stockDstP: myStockIssuerP.e.makeEmptyPurse('aliceStockDst'),
         stockNeeded: 7,
-        cancellationP: f.makeVow(function(r) {
-          cancel = r;
-        }),
+        cancellationP: f.makeVow(r => (cancel = r)),
       });
       const ackP = a.moneySrcP.e.deposit(10, myMoneyPurseP);
 

--- a/examples/contractHost/bob/source/index.js
+++ b/examples/contractHost/bob/source/index.js
@@ -14,10 +14,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/* eslint-disable-next-line global-require, import/no-extraneous-dependencies */
 import harden from '@agoric/harden';
 
 export default function(argv) {
-  const escrowSrc = argv.escrowSrc;
+  const { escrowSrc } = argv;
   const contractHostP = Vow.resolve(argv.host);
   const aliceP = Vow.resolve(argv.alice);
 
@@ -35,10 +36,11 @@ export default function(argv) {
     myMoneyIssuerP = myMoneyPurseP.e.getIssuer();
     myStockPurseP = Vow.resolve(myStockPurse);
     myStockIssuerP = myStockPurseP.e.getIssuer();
-    return bob;
+    /* eslint-disable-next-line no-use-before-define */
+    return bob; // bob and init use each other
   }
 
-  const check = function(allegedSrc, allegedSide) {
+  const check = (_allegedSrc, _allegedSide) => {
     // for testing purposes, alice and bob are willing to play
     // any side of any contract, so that the failure we're testing
     // is in the contractHost's checking
@@ -56,6 +58,7 @@ export default function(argv) {
       if (!initialized) {
         console.log('++ ERR: buy called before init()');
       }
+      /* eslint-disable-next-line no-unused-vars */
       let amount;
       let good;
       desc = `${desc}`;
@@ -90,7 +93,7 @@ export default function(argv) {
         Vow.resolve(bob).e.invite(bobTokenP, escrowSrc, 1),
       ]);
       doneP.then(
-        res => console.log('++ bob.tradeWell done'),
+        _res => console.log('++ bob.tradeWell done'),
         rej => console.log('++ bob.tradeWell reject', rej),
       );
       return doneP;
@@ -108,14 +111,13 @@ export default function(argv) {
       console.log('++ bob.invite start');
       check(allegedSrc, allegedSide);
       console.log('++ bob.invite passed check');
+      /* eslint-disable-next-line no-unused-vars */
       let cancel;
       const b = harden({
         stockSrcP: myStockIssuerP.e.makeEmptyPurse('bobStockSrc'),
         moneyDstP: myMoneyIssuerP.e.makeEmptyPurse('bobMoneyDst'),
         moneyNeeded: 10,
-        cancellationP: f.makeVow(function(r) {
-          cancel = r;
-        }),
+        cancellationP: f.makeVow(r => (cancel = r)),
       });
       const ackP = b.stockSrcP.e.deposit(7, myStockPurseP);
 


### PR DESCRIPTION
## Errors
Alice:
![screen shot 2019-02-21 at 12 42 38 pm](https://user-images.githubusercontent.com/2441069/53201509-118adf80-35d9-11e9-9402-5c0ca1008c66.png)
Bob:
![screen shot 2019-02-21 at 12 47 05 pm](https://user-images.githubusercontent.com/2441069/53201508-10f24900-35d9-11e9-86ea-3135e03aa5da.png)

## Fixes
1. Allow require of harden
2. Allow `mint` and `alice` to reference each other, same for `mint` and `bob`
3. fix intentionally unused args and vars
4. change unnamed function to arrow style
