### PR TITLE
ESLint changes to examples/contractHost/escrow.js

### DIFF
--- a/examples/contractHost/escrow.js
+++ b/examples/contractHost/escrow.js
@@ -1,7 +1,9 @@
 /* global Vow */
+
+/* eslint-disable-next-line global-require, import/no-extraneous-dependencies */
 const harden = require('@agoric/harden');
 
-function escrowExchange(a, b) {
+export default function escrowExchange(a, b) {
   // a from Alice , b from Bob
   function makeTransfer(srcPurseP, dstPurseP, amount) {
     const issuerP = Vow.join(srcPurseP.e.getIssuer(), dstPurseP.e.getIssuer());
@@ -32,7 +34,7 @@ function escrowExchange(a, b) {
     failOnly(a.cancellationP),
     failOnly(b.cancellationP),
   ]).then(
-    x => Vow.all([aT.phase2(), bT.phase2()]),
-    ex => Vow.all([aT.abort(), bT.abort()]),
+    _x => Vow.all([aT.phase2(), bT.phase2()]),
+    _ex => Vow.all([aT.abort(), bT.abort()]),
   );
 }


### PR DESCRIPTION
## Errors

<img width="818" alt="screen shot 2019-02-21 at 1 44 08 pm" src="https://user-images.githubusercontent.com/2441069/53203995-75b0a200-35df-11e9-9152-8f6bfc37e25c.png">

## Fixes
1. allow import of harden
2. allow intentionally unused args
3. export escrowExchange as default