### PR TITLE
ESLint changes to examples/contract/simple_auction.js

### DIFF
--- a/examples/contract/simple_auction.js
+++ b/examples/contract/simple_auction.js
@@ -1,3 +1,8 @@
+/* eslint-disable */
+// Note: Currently has parsing error preventing ESLint from running:
+//  66:67  error  Parsing error: Unexpected token )
+
+
 // Copyright (C) 2013 Vrije Universiteit Brussel
 //
 // Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Because simple_auction has parsing errors and seems to be in progress, I think we should not try to enforce the ESLint rules at this point. Thoughts?