### PR TITLE
ESLint changes to src/vat/executionEngine.js

### DIFF
--- a/src/vat/executionEngine.js
+++ b/src/vat/executionEngine.js
@@ -1,4 +1,6 @@
 // the execution engine
+
+/* eslint-disable-next-line import/no-extraneous-dependencies */
 import harden from '@agoric/harden';
 import { doSwissHashing } from './swissCrypto';
 import { makeWebkeyMarshal } from './webkey';
@@ -17,10 +19,12 @@ export function makeEngine(
   manager,
 ) {
   function allocateSwissStuff() {
+    /* eslint-disable-next-line no-use-before-define */
     return marshal.allocateSwissStuff();
   }
 
   function registerRemoteVow(vatID, swissnum, resultVow) {
+    /* eslint-disable-next-line no-use-before-define */
     marshal.registerRemoteVow(vatID, swissnum, resultVow);
   }
 
@@ -31,8 +35,8 @@ export function makeEngine(
     targetSwissnum,
     methodName,
     args,
-    resolutionOf,
   ) {
+    /* eslint-disable-next-line no-use-before-define */
     const argsS = marshal.serialize(harden(args), resolutionOf);
     const body = harden({
       op: 'send',
@@ -55,6 +59,7 @@ export function makeEngine(
     allocateSwissStuff,
     registerRemoteVow,
   };
+
   const marshal = makeWebkeyMarshal(
     hash58,
     Vow,
@@ -79,11 +84,6 @@ export function makeEngine(
     manager.sendTo(targetVatID, body);
   }
 
-  function rxSendOnly(opMsg) {
-    // currently just for tests
-    return doSendInternal(opMsg);
-  }
-
   function doSendInternal(opMsg) {
     const target = marshal.getMyTargetBySwissnum(opMsg.targetSwissnum);
     if (!target) {
@@ -96,6 +96,11 @@ export function makeEngine(
     // todo: sometimes causes turn delay, could fastpath if target is
     // resolved
     return Vow.resolve(target).e[opMsg.methodName](...args);
+  }
+
+  function rxSendOnly(opMsg) {
+    // currently just for tests
+    return doSendInternal(opMsg);
   }
 
   function rxMessage(senderVatID, opMsg) {

--- a/src/vat/executionEngine.js
+++ b/src/vat/executionEngine.js
@@ -35,6 +35,8 @@ export function makeEngine(
     targetSwissnum,
     methodName,
     args,
+    /* eslint-disable-next-line no-shadow */
+    resolutionOf,
   ) {
     /* eslint-disable-next-line no-use-before-define */
     const argsS = marshal.serialize(harden(args), resolutionOf);


### PR DESCRIPTION
## Errors

![screen shot 2019-02-22 at 11 25 20 am](https://user-images.githubusercontent.com/2441069/53266479-b4a12f00-3695-11e9-952c-b7a7f056a0fd.png)

## Fixes

1. Allow the import of harden
2. Allow `marshal` to be used before define. `makeWebkeyMarshal` takes in `serializer` as a parameter, which uses `allocateSwissStuff` which references `marshal`, so there's not an easy reordering here.
3. Move `rxSendOnly` down to fix `doSendInternal` use before define
4. remove `resolutionOf` as a parameter, since it shadows an import. I believe this was a mistake, but I'm not 100% certain. 