### PR TITLE
ESLint changes to src/vat/index.js

### DIFF
--- a/src/vat/index.js
+++ b/src/vat/index.js
@@ -1,3 +1,5 @@
+/* global SES */
+
 // this file is evaluated in the SES realm and defines the Vat. It gets one
 // endowments: 'module' (used to export everything). This comes from the
 // primal realm, so it must not be exposed to guest code.
@@ -10,12 +12,13 @@ import {
   Vow,
   makePresence,
   makeUnresolvedRemoteVow,
+  resolutionOf, // todo unclean
+  handlerOf, // todo unclean
 } from '../flow/flowcomm';
-import { resolutionOf, handlerOf } from '../flow/flowcomm'; // todo unclean
 import { makeRemoteManager } from './remotes';
 import { makeEngine } from './executionEngine';
 
-const msgre = /^msg: (\w+)->(\w+) (.*)$/;
+// const msgre = /^msg: (\w+)->(\w+) (.*)$/;
 
 function confineGuestSource(source, endowments) {
   endowments = endowments || {};
@@ -162,17 +165,13 @@ export function makeVat(
     manager,
   );
   manager.setEngine(engine);
-  const marshal = engine.marshal;
+  // const { marshal } = engine; // used in comment
   endowments.comms.registerManager(manager);
 
   // This is the host's interface to the Vat. It must act as a sort of
   // airlock: host objects passed into these functions should not be exposed
   // to other code, to avoid accidentally exposing primal-realm
   // Object/Function/etc.
-
-  function buildSturdyRef(vatID, swissnum) {
-    return `${vatID}/${swissnum}`;
-  }
 
   return {
     check() {
@@ -245,7 +244,7 @@ export function makeVat(
         return;
       }
       if (line.startsWith('load: ')) {
-        const arg = /^load: (\w+)$/.exec(line)[1];
+        // const arg = /^load: (\w+)$/.exec(line)[1];
         //      if (arg !== initialSourceHash) {
         //        throw Error(`err: input says to load ${arg}, but we loaded ${initialSourceHash}`);
         //      }


### PR DESCRIPTION
## Errors
![screen shot 2019-02-22 at 11 41 54 am](https://user-images.githubusercontent.com/2441069/53267189-95a39c80-3697-11e9-89e1-d6b38fc2863f.png)

## Fixes
1. Add SES as global
1. Combine flowcomm imports, but keep comments.
2. Comment out unused `msgre`. There is a later `msgre`, so I assume this might be switched to in the future. Could be wrong on this.
3. comment out the definition of marshal, since it is only used in commented out code. 
4. Remove unused buildSturdyRef - this is unused entirely. We could decide to keep this instead. 
5. comment out `arg` which is only used in commented out code