### PR TITLE
ESLint changes to src/vat/notifyUponResolution.js

### DIFF
--- a/src/vat/notifyUponResolution.js
+++ b/src/vat/notifyUponResolution.js
@@ -1,16 +1,15 @@
-export function makeResolutionNotifier(myVatID, opResolve) {
+export function makeResolutionNotifier(_myVatID, opResolve) {
   const resolutionNotifiers = new WeakMap(); // vow -> { swissnum, Set(vatID) }
 
-  const nurCount = 60;
   function notifyUponResolution(value, targetVatID, swissnum) {
     // console.log(`notifyUponResolution for my ${myVatID} ${swissnum} to ${targetVatID}`);
     if (targetVatID === null) {
       return;
     }
 
-    function notify(id, swissnum, result) {
+    function notify(id, notifySwissnum, result) {
       // console.log('  to', id, swissnum);
-      opResolve(id, swissnum, result);
+      opResolve(id, notifySwissnum, result);
     }
 
     if (!resolutionNotifiers.has(value)) {
@@ -22,17 +21,18 @@ export function makeResolutionNotifier(myVatID, opResolve) {
         // c,
       };
       resolutionNotifiers.set(value, rec);
+      /* eslint-disable-next-line no-inner-declarations */
       function done(result) {
         rec.resolved = true;
         // todo: there's probably a race here, if somehow opResolve reenters
         // into notifyUponResolution and adds a new follower. Unlikely but
         // untidy.
-        for (const id of rec.followers) {
-          // TODO: notification order depends upon Set iteration, will this
-          // cause nondeterminism? OTOH, these messages are strictly sent to
-          // different vats, so it isn't observable by a single outside vat
-          notify(id, swissnum, result);
-        }
+
+        // TODO: notification order depends upon Set iteration, will this
+        // cause nondeterminism? OTOH, these messages are strictly sent to
+        // different vats, so it isn't observable by a single outside vat
+        const followersArray = Array.from(rec.followers);
+        followersArray.forEach(id => notify(id, swissnum, result));
       }
       value.then(done, done);
     }
@@ -45,6 +45,7 @@ export function makeResolutionNotifier(myVatID, opResolve) {
 
     if (rec.resolved) {
       // done() already fired, this late follower needs to catch up
+      /* eslint-disable-next-line no-inner-declarations */
       function notifyNow(result) {
         notify(targetVatID, swissnum, result);
       }


### PR DESCRIPTION
## Errors

![screen shot 2019-02-22 at 11 53 41 am](https://user-images.githubusercontent.com/2441069/53268132-1d8aa600-369a-11e9-8863-74e9a514f24c.png)

## Fixes
1. Mark `myVatID` as an unused arg with a `_` prefix
2. remove `nurCount` since unused
3. Rename `swissnum` that is a parameter of `notify` and which shadows the upper `swissnum` 
4. Change `for..of` to a `forEach`
5. Allow inner declarations [because we are using ES6](https://eslint.org/docs/rules/no-inner-declarations#when-not-to-use-it)