### PR TITLE
ESLint changes -- small misc changes only

### DIFF
--- a/examples/contract/simple_auction.js
+++ b/examples/contract/simple_auction.js
@@ -68,7 +68,7 @@ define('contract/simple_auction', ['Q'], function(Q) {
               maxBid = bid;
             });
           } else {
-            throw new Error("bid too low. Minimum bid: " + maxBid));
+            throw new Error("bid too low. Minimum bid: " + maxBid);
           }
         });
       
@@ -133,7 +133,7 @@ define('contract/simple_auction', ['Q'], function(Q) {
                    moneyDstP: purse,
                    moneyNeeded: maxBid,
                    good: good,
-                   cancellationP: ...
+                   cancellationP: {}, //TODO: {} is just a placeholder
                  }));
               });
             },

--- a/src/flow/flowcomm.js
+++ b/src/flow/flowcomm.js
@@ -241,6 +241,8 @@ class FarRemoteHandler extends UnresolvedHandler {
 
   // Unblock flows so that messages are delivered
   // TODO: flow interation here must be fixed when we enforce ordering
+
+  /* eslint-disable-next-line consistent-return */
   processBlockedFlows(blockedFlows) {
     if (this.value) {
       blockedFlows.forEach(flow => {
@@ -449,6 +451,7 @@ const vowToInner = new WeakMap();
 const resolverToInner = new WeakMap();
 
 // TODO change to throw TypeError if these aren't present.
+/* eslint-disable-next-line no-unused-vars */
 function validInnerResolver(value) {
   const result = resolverToInner.get(value);
   insist(result, 'Valid instance required');
@@ -502,6 +505,7 @@ class InnerVow {
       : (...args) => {
           const handler = new UnresolvedHandler();
           // TODO don't make an outer resolver
+          /* eslint-disable-next-line no-unused-vars */
           const resultR = makeResolver(handler);
           this.flow.enqueue(this, new PendingDelivery(op, args, handler));
           /* eslint-disable-next-line no-constant-condition */

--- a/src/host.js
+++ b/src/host.js
@@ -1,5 +1,3 @@
-/* global def */
-
 // this defines the endowments that live in the primal realm and may be
 // granted to the Vat host. It is the "airlock" or Membrane that sits between
 // the primal realm and the SES realm, specialized for the specific
@@ -16,7 +14,6 @@ import bs58 from 'bs58';
 export function hash58(s) {
   // this takes a string (unicode), encodes it to UTF-8, then hashes it.
   // We use SHA256 truncated to 128 bits for our swissnums.
-  const buf = Buffer.from(s, 'utf8');
   const h = crypto.createHash('sha256');
   h.update(s);
   return bs58.encode(h.digest().slice(0, 16));
@@ -44,14 +41,16 @@ export function makeVatEndowments(s, req, output, comms) {
     },
   };
 
+  /* eslint-disable-next-line no-shadow */
   function build(power) {
+    /* eslint-disable-next-line global-require, import/no-extraneous-dependencies */
     const harden = require('@agoric/harden');
     function eventually(f) {
       Promise.resolve().then(_ => f());
     }
     return harden({
-      hash58(s) {
-        return power.hash58(s);
+      hash58(str) {
+        return power.hash58(str);
       },
       comms: {
         registerManager(m) {
@@ -96,8 +95,8 @@ export function makeVatEndowments(s, req, output, comms) {
           eventually(_ => power.comms.wantConnection(`${hostID}`));
         },
       },
-      writeOutput(s) {
-        power.output.write(s);
+      writeOutput(str) {
+        power.output.write(str);
         power.output.write('\n');
       },
       exit(rc, message) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
 // Set options as a parameter, environment variable, or rc file.
+/* eslint-disable-next-line no-global-assign, import/no-extraneous-dependencies */
 require = require('esm')(module /* , options */);
 module.exports = require('./main.js');

--- a/src/vat/webkey.js
+++ b/src/vat/webkey.js
@@ -1,14 +1,7 @@
-
+/* eslint-disable-next-line import/no-extraneous-dependencies */
 import harden from '@agoric/harden';
 import { makeSwissnum, makeSwissbase, doSwissHashing } from './swissCrypto';
-import {
-  isVow,
-  asVow,
-  Flow,
-  Vow,
-  makePresence,
-  makeUnresolvedRemoteVow,
-} from '../flow/flowcomm';
+import { isVow, makePresence, makeUnresolvedRemoteVow } from '../flow/flowcomm';
 
 // objects can only be passed in one of two/three forms:
 // 1: pass-by-presence: all properties (own and inherited) are methods,

--- a/test/m1/index.js
+++ b/test/m1/index.js
@@ -1,5 +1,6 @@
 import { m2 } from './m2';
 
+/* eslint-disable-next-line no-unused-vars */
 const a = 2;
 
 export function foo() {

--- a/test/m1/m2.js
+++ b/test/m1/m2.js
@@ -1,6 +1,5 @@
 function m2() {
   console.log('in m2');
-  debugger;
   return 1;
 }
 

--- a/test/test-contract.js
+++ b/test/test-contract.js
@@ -19,7 +19,7 @@ async function buildContractVat(source = '../examples/contract') {
     outputTranscript.push(line);
   }
   const s = makeRealm({ consoleMode: 'allow', errorStackMode: 'allow' });
-  const req = s.makeRequire({'@agoric/nat': Nat, '@agoric/harden': true});
+  const req = s.makeRequire({ '@agoric/nat': Nat, '@agoric/harden': true });
   const contractTestSource = await bundleCode(require.resolve(source));
   const endow = { writeOutput, comms: { registerManager() {} }, hash58 };
   const v = await buildVat(

--- a/test/test-endowments.js
+++ b/test/test-endowments.js
@@ -9,8 +9,11 @@ import {
 } from '../src/vat/swissCrypto';
 
 test('hash58', t => {
-  const s = SES.makeSESRootRealm({consoleMode: 'allow', errorStackMode: 'allow'});
-  const req = s.makeRequire({'@agoric/nat': Nat, '@agoric/harden': true});
+  const s = SES.makeSESRootRealm({
+    consoleMode: 'allow',
+    errorStackMode: 'allow',
+  });
+  const req = s.makeRequire({ '@agoric/nat': Nat, '@agoric/harden': true });
   const e = makeVatEndowments(s, req, null, null);
   // test vectors from python and electrum/lib/address.py Base58 class
   // Base58.encode(hashlib.sha256(s).digest()[:16])
@@ -27,7 +30,7 @@ test('hash58', t => {
 
 test.skip('swissHashing', t => {
   const s = SES.makeSESRootRealm();
-  const req = s.makeRequire({'@agoric/nat': Nat, '@agoric/harden': true});
+  const req = s.makeRequire({ '@agoric/nat': Nat, '@agoric/harden': true });
   const e = makeVatEndowments(s, req, null, null);
   const vs = e.hash58('vat secret');
   t.equal(vs, 'WHMV2quAubLYGoFtXtpEao');

--- a/test/test-marshal.js
+++ b/test/test-marshal.js
@@ -20,6 +20,7 @@ test('marshal', async t => {
   const req = s.makeRequire({ '@agoric/nat': Nat, '@agoric/harden': true });
   const e = confineVatSource(s, req, code);
   const endowments = makeVatEndowments(s, req, null, null);
+  /* eslint-disable-next-line no-unused-vars */
   const { hash58: hash58Endowed } = endowments;
 
   function helpers() {

--- a/test/test-nat.js
+++ b/test/test-nat.js
@@ -1,5 +1,3 @@
-/* global Nat */
-
 import { test } from 'tape-promise/tape';
 import Nat from '@agoric/nat';
 import SES from 'ses';
@@ -7,6 +5,7 @@ import { confineVatSource } from '../src/main';
 
 function s1() {
   exports.foo = a => {
+    /* eslint-disable-next-line no-shadow, global-require */
     const Nat = require('@agoric/nat');
     return Nat(a);
   };
@@ -21,7 +20,7 @@ function funcToSource(f) {
 
 test('Nat', t => {
   const s = SES.makeSESRootRealm();
-  const req = s.makeRequire({'@agoric/nat': Nat, '@agoric/harden': true});
+  const req = s.makeRequire({ '@agoric/nat': Nat, '@agoric/harden': true });
   const s1code = funcToSource(s1);
   const n = confineVatSource(s, req, s1code).foo;
   t.equal(n(2), 2);

--- a/test/test-pipeline.js
+++ b/test/test-pipeline.js
@@ -55,7 +55,7 @@ test('promise pipelining', async t => {
     hash58,
   };
   const s = makeRealm();
-  const req = s.makeRequire({'@agoric/nat': Nat, '@agoric/harden': true});
+  const req = s.makeRequire({ '@agoric/nat': Nat, '@agoric/harden': true });
   const v1 = await buildVat(
     s,
     req,
@@ -226,7 +226,7 @@ test('promise pipelining to third party', async t => {
     hash58,
   };
   const s = makeRealm();
-  const req = s.makeRequire({'@agoric/nat': Nat, '@agoric/harden': true});
+  const req = s.makeRequire({ '@agoric/nat': Nat, '@agoric/harden': true });
   const v1 = await buildVat(
     s,
     req,

--- a/test/test-sourcemap.js
+++ b/test/test-sourcemap.js
@@ -6,6 +6,7 @@ test('build source map from module', async t => {
   const s = SES.makeSESRootRealm();
   const code = await bundleCode(require.resolve('./m1'), true);
   // console.log(code);
+  /* eslint-disable-next-line no-unused-vars */
   const exports = confineVatSource(s, code);
   // exports.foo();
   const lines = code.split('\n');


### PR DESCRIPTION
This is a whole bunch of little changes, many of which are automatic due to --fix. The recent changes to Playground Vat added some things that weren't fixed by our first pass. 

This PR also includes fixes to a few remaining issues in files that have already gone through the review process:
1. We fix the parsing errors in simple_auction, because if ESLint can't parse it, it errors, even with `eslint-disable`
2. We allow unused vars and inconsistent returns in flowcomm.js.
3. Allow harden to be imported
4. Allow some unused vars, allow some shadowed vars

Does not include main.js, remotes.js or scoreboard.js since those files have ESLint changes that are still to be merged.

Once those other PRs are merged in, this PR makes it so that we have no ESLint errors.
